### PR TITLE
TRUS-1698 Removing the predicate for agent enrolment

### DIFF
--- a/app/uk/gov/hmrc/trusts/models/requests/IdentifierRequest.scala
+++ b/app/uk/gov/hmrc/trusts/models/requests/IdentifierRequest.scala
@@ -19,4 +19,5 @@ package uk.gov.hmrc.trusts.models.requests
 import play.api.mvc.{Request, WrappedRequest}
 import uk.gov.hmrc.auth.core.AffinityGroup
 
-case class IdentifierRequest[A] (request: Request[A], identifier: String, affinityGroup: AffinityGroup, agentARN: Option[String] = None) extends WrappedRequest[A](request)
+case class IdentifierRequest[A] (request: Request[A], identifier: String, affinityGroup: AffinityGroup)
+  extends WrappedRequest[A](request)


### PR DESCRIPTION
- Only checking the authorised() endpoint and retrieving the affinity
group from auth