### PR TITLE
TRUS-test-speedup: Set patience interval to 0 to speed up unit tests

### DIFF
--- a/test/uk/gov/hmrc/trusts/BaseSpec.scala
+++ b/test/uk/gov/hmrc/trusts/BaseSpec.scala
@@ -65,7 +65,7 @@ class BaseSpec extends WordSpec
     .withBody(Json.parse("{}"))
 
   implicit val defaultPatience =
-    PatienceConfig(timeout = Span(5, Seconds), interval = Span(500, Millis))
+    PatienceConfig(timeout = Span(5, Seconds), interval = Span(0, Millis))
 
   def postRequestWithPayload(payload: JsValue, withDraftId: Boolean = true): FakeRequest[JsValue] = {
     if (withDraftId) {

--- a/test/uk/gov/hmrc/trusts/BaseSpec.scala
+++ b/test/uk/gov/hmrc/trusts/BaseSpec.scala
@@ -64,9 +64,6 @@ class BaseSpec extends WordSpec
     .withHeaders(Headers.DraftRegistrationId -> UUID.randomUUID().toString)
     .withBody(Json.parse("{}"))
 
-  implicit val defaultPatience =
-    PatienceConfig(timeout = Span(5, Seconds), interval = Span(0, Millis))
-
   def postRequestWithPayload(payload: JsValue, withDraftId: Boolean = true): FakeRequest[JsValue] = {
     if (withDraftId) {
       FakeRequest("POST", "/trusts/register")

--- a/test/uk/gov/hmrc/trusts/connectors/BaseConnectorSpec.scala
+++ b/test/uk/gov/hmrc/trusts/connectors/BaseConnectorSpec.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.trusts.connectors
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, containing, equalTo, get, post, put, urlEqualTo}
+import org.scalatest.time.{Millis, Seconds, Span}
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsValue, Json}
 import play.api.test.Helpers.CONTENT_TYPE
@@ -25,6 +26,9 @@ import uk.gov.hmrc.trusts.BaseSpec
 import uk.gov.hmrc.trusts.utils.WireMockHelper
 
 class BaseConnectorSpec extends BaseSpec with WireMockHelper {
+
+  implicit val defaultPatience =
+    PatienceConfig(timeout = Span(5, Seconds), interval = Span(15, Millis))
 
   override def applicationBuilder(): GuiceApplicationBuilder = {
     super.applicationBuilder()

--- a/test/uk/gov/hmrc/trusts/connectors/TaxEnrolmentConnectorSpec.scala
+++ b/test/uk/gov/hmrc/trusts/connectors/TaxEnrolmentConnectorSpec.scala
@@ -16,11 +16,15 @@
 
 package uk.gov.hmrc.trusts.connectors
 
+import org.scalatest.time.{Millis, Seconds, Span}
 import uk.gov.hmrc.trusts.connector.TaxEnrolmentConnector
 import uk.gov.hmrc.trusts.exceptions.{BadRequestException, InternalServerErrorException}
 import uk.gov.hmrc.trusts.models.TaxEnrolmentSuccess
 
 class TaxEnrolmentConnectorSpec extends BaseConnectorSpec {
+
+  implicit val defaultPatience =
+    PatienceConfig(timeout = Span(5, Seconds), interval = Span(15, Millis))
 
   lazy val connector: TaxEnrolmentConnector = injector.instanceOf[TaxEnrolmentConnector]
 

--- a/test/uk/gov/hmrc/trusts/connectors/TaxEnrolmentConnectorSpec.scala
+++ b/test/uk/gov/hmrc/trusts/connectors/TaxEnrolmentConnectorSpec.scala
@@ -23,9 +23,6 @@ import uk.gov.hmrc.trusts.models.TaxEnrolmentSuccess
 
 class TaxEnrolmentConnectorSpec extends BaseConnectorSpec {
 
-  implicit val defaultPatience =
-    PatienceConfig(timeout = Span(5, Seconds), interval = Span(15, Millis))
-
   lazy val connector: TaxEnrolmentConnector = injector.instanceOf[TaxEnrolmentConnector]
 
   ".enrolSubscriber" should {


### PR DESCRIPTION
Remove the delay loops…