### PR TITLE
Changing approach to provisional flag for` trustees

### DIFF
--- a/app/uk/gov/hmrc/trusts/controllers/GetTrustController.scala
+++ b/app/uk/gov/hmrc/trusts/controllers/GetTrustController.scala
@@ -92,10 +92,6 @@ class GetTrustController @Inject()(identify: IdentifierAction,
       case _ => Forbidden
     }
 
-  def transformTrusteesToMaintainJson = {
-
-  }
-
   def getTrustees(utr: String) : Action[AnyContent] =
     doGet(utr, applyTransformations = true) {
       case processed: TrustProcessedResponse =>

--- a/app/uk/gov/hmrc/trusts/models/JsonWithoutNulls.scala
+++ b/app/uk/gov/hmrc/trusts/models/JsonWithoutNulls.scala
@@ -14,21 +14,23 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.trusts.transformers
+package uk.gov.hmrc.trusts.models
 
-import play.api.libs.json._
-import uk.gov.hmrc.trusts.models.get_trust_or_estate.get_trust.DisplayTrustTrusteeOrgType
+import play.api.libs.json.{JsNull, JsObject, JsValue}
 
-case class AddTrusteeOrgTransform(trustee: DisplayTrustTrusteeOrgType) extends DeltaTransform with AddTrusteeCommon {
+object JsonWithoutNulls {
 
-  override def applyTransform(input: JsValue): JsResult[JsValue] = {
-    addTrustee(input, Json.toJson(trustee), TrusteeOrg)
+  implicit class JsonWithoutNullValues(json: JsValue) {
+
+    def withoutNulls : JsValue = json match {
+      case JsObject(fields) =>
+        JsObject(fields.flatMap {
+          case (_, JsNull) => None
+          case notNullField @ (_, value) => Some(notNullField)
+        })
+      case other => other
+    }
+
   }
-}
 
-object AddTrusteeOrgTransform {
-
-  val key = "AddTrusteeOrgTransform"
-
-  implicit val format: Format[AddTrusteeOrgTransform] = Json.format[AddTrusteeOrgTransform]
 }

--- a/app/uk/gov/hmrc/trusts/models/get_trust_or_estate/ResponseModels.scala
+++ b/app/uk/gov/hmrc/trusts/models/get_trust_or_estate/ResponseModels.scala
@@ -19,20 +19,20 @@ package uk.gov.hmrc.trusts.models.get_trust_or_estate
 import uk.gov.hmrc.trusts.models.get_trust_or_estate.get_estate.GetEstateResponse
 import uk.gov.hmrc.trusts.models.get_trust_or_estate.get_trust.GetTrustResponse
 
-sealed trait ErrorResponse extends GetTrustResponse with GetEstateResponse
+sealed trait TrustErrorResponse extends GetTrustResponse with GetEstateResponse
 
-case object InvalidUTRResponse extends ErrorResponse
+case object InvalidUTRResponse extends TrustErrorResponse
 
-case object InvalidRegimeResponse extends ErrorResponse
+case object InvalidRegimeResponse extends TrustErrorResponse
 
-case object BadRequestResponse extends ErrorResponse
+case object BadRequestResponse extends TrustErrorResponse
 
-case object ResourceNotFoundResponse extends ErrorResponse
+case object ResourceNotFoundResponse extends TrustErrorResponse
 
-case object InternalServerErrorResponse extends ErrorResponse
+case object InternalServerErrorResponse extends TrustErrorResponse
 
-case object NotEnoughDataResponse extends ErrorResponse
+case object NotEnoughDataResponse extends TrustErrorResponse
 
-case object ServiceUnavailableResponse extends ErrorResponse
+case object ServiceUnavailableResponse extends TrustErrorResponse
 
-case class TransformationErrorResponse(errors: String) extends ErrorResponse
+case class TransformationErrorResponse(errors: String) extends TrustErrorResponse

--- a/app/uk/gov/hmrc/trusts/models/get_trust_or_estate/get_trust/GetTrustResponse.scala
+++ b/app/uk/gov/hmrc/trusts/models/get_trust_or_estate/get_trust/GetTrustResponse.scala
@@ -22,6 +22,7 @@ import play.api.libs.json._
 import uk.gov.hmrc.http.{HttpReads, HttpResponse}
 import uk.gov.hmrc.trusts.models._
 import uk.gov.hmrc.trusts.models.get_trust_or_estate.{ResponseHeader, _}
+import uk.gov.hmrc.trusts.transformers.mdtp.Trustees
 
 trait GetTrustResponse
 trait GetTrustSuccessResponse extends GetTrustResponse {

--- a/app/uk/gov/hmrc/trusts/models/get_trust_or_estate/get_trust/GetTrustResponse.scala
+++ b/app/uk/gov/hmrc/trusts/models/get_trust_or_estate/get_trust/GetTrustResponse.scala
@@ -29,7 +29,17 @@ trait GetTrustSuccessResponse extends GetTrustResponse {
 }
 
 case class TrustProcessedResponse(getTrust: JsValue,
-                              responseHeader: ResponseHeader) extends GetTrustSuccessResponse
+                              responseHeader: ResponseHeader) extends GetTrustSuccessResponse {
+
+  def transform : GetTrustResponse = {
+    getTrust.transform(
+      Trustees.transform(getTrust)
+    ).map {
+      json => TrustProcessedResponse(json, responseHeader)
+    }.getOrElse(InternalServerErrorResponse)
+  }
+
+}
 
 object TrustProcessedResponse {
   val mongoWrites: Writes[TrustProcessedResponse] = new Writes[TrustProcessedResponse] {
@@ -45,7 +55,7 @@ object GetTrustSuccessResponse {
 
 
   implicit val writes: Writes[GetTrustSuccessResponse] = Writes{
-    case TrustProcessedResponse(trust, header) =>Json.obj("responseHeader" -> header, "getTrust" -> Json.toJson(trust.as[GetTrust]))
+    case TrustProcessedResponse(trust, header) => Json.obj("responseHeader" -> header, "getTrust" -> Json.toJson(trust.as[GetTrust]))
     case TrustFoundResponse(header) => Json.obj("responseHeader" -> header)
   }
 

--- a/app/uk/gov/hmrc/trusts/models/get_trust_or_estate/get_trust/GetTrustSchemaModels.scala
+++ b/app/uk/gov/hmrc/trusts/models/get_trust_or_estate/get_trust/GetTrustSchemaModels.scala
@@ -300,21 +300,27 @@ case class DisplayTrustTrusteeOrgType(lineNo: Option[String],
                                       phoneNumber: Option[String] = None,
                                       email: Option[String] = None,
                                       identification: Option[DisplayTrustIdentificationOrgType],
-                                      entityStart: DateTime,
-                                      provisional: Option[Boolean]
-                                     ) {
-  def withProvisional = {
-    if(this.provisional.isDefined) {
-      this
-    } else {
-      this.copy(provisional = Some(false))
-    }
-  }
-}
+                                      entityStart: DateTime)
 
 object DisplayTrustTrusteeOrgType {
+
   implicit val dateFormat: Format[DateTime] = Format[DateTime](Reads.jodaDateReads(dateTimePattern), Writes.jodaDateWrites(dateTimePattern))
   implicit val trusteeOrgTypeFormat: Format[DisplayTrustTrusteeOrgType] = Json.format[DisplayTrustTrusteeOrgType]
+
+  import uk.gov.hmrc.trusts.models.JsonWithoutNulls._
+
+  val writeToMaintain : Writes[DisplayTrustTrusteeOrgType] = new Writes[DisplayTrustTrusteeOrgType] {
+    override def writes(o: DisplayTrustTrusteeOrgType): JsValue = Json.obj(
+      "lineNo" -> o.lineNo,
+      "bpMatchStatus" -> o.bpMatchStatus,
+      "name" -> o.name,
+      "phoneNumber" -> o.phoneNumber,
+      "email" -> o.email,
+      "identification" -> o.identification,
+      "entityStart" -> o.entityStart,
+      "provisional" -> o.lineNo.isDefined
+    ).withoutNulls
+  }
 }
 
 case class DisplayTrustTrusteeIndividualType(lineNo: Option[String],
@@ -323,24 +329,28 @@ case class DisplayTrustTrusteeIndividualType(lineNo: Option[String],
                                              dateOfBirth: Option[DateTime],
                                              phoneNumber: Option[String],
                                              identification: Option[DisplayTrustIdentificationType],
-                                             entityStart: DateTime,
-                                             provisional: Option[Boolean]
-                                            ) {
-
-  def withProvisional = {
-    if(this.provisional.isDefined) {
-      this
-    } else {
-      this.copy(provisional = Some(false))
-    }
-  }
-
-}
+                                             entityStart: DateTime
+                                            )
 
 object DisplayTrustTrusteeIndividualType {
 
+  import uk.gov.hmrc.trusts.models.JsonWithoutNulls._
+
   implicit val dateFormat: Format[DateTime] = Format[DateTime](Reads.jodaDateReads(dateTimePattern), Writes.jodaDateWrites(dateTimePattern))
   implicit val trusteeIndividualTypeFormat: Format[DisplayTrustTrusteeIndividualType] = Json.format[DisplayTrustTrusteeIndividualType]
+
+  val writeToMaintain : Writes[DisplayTrustTrusteeIndividualType] = new Writes[DisplayTrustTrusteeIndividualType] {
+    override def writes(o: DisplayTrustTrusteeIndividualType): JsValue = Json.obj(
+      "lineNo" -> o.lineNo,
+      "bpMatchStatus" -> o.bpMatchStatus,
+      "name" -> o.name,
+      "dateOfBirth" -> o.dateOfBirth,
+      "phoneNumber" -> o.phoneNumber,
+      "identification" -> o.identification,
+      "entityStart" -> o.entityStart,
+      "provisional" -> o.lineNo.isDefined
+    ).withoutNulls
+  }
 }
 
 

--- a/app/uk/gov/hmrc/trusts/models/get_trust_or_estate/get_trust/GetTrustSchemaModels.scala
+++ b/app/uk/gov/hmrc/trusts/models/get_trust_or_estate/get_trust/GetTrustSchemaModels.scala
@@ -318,7 +318,7 @@ object DisplayTrustTrusteeOrgType {
       "email" -> o.email,
       "identification" -> o.identification,
       "entityStart" -> o.entityStart,
-      "provisional" -> o.lineNo.isDefined
+      "provisional" -> o.lineNo.isEmpty
     ).withoutNulls
   }
 }
@@ -348,7 +348,7 @@ object DisplayTrustTrusteeIndividualType {
       "phoneNumber" -> o.phoneNumber,
       "identification" -> o.identification,
       "entityStart" -> o.entityStart,
-      "provisional" -> o.lineNo.isDefined
+      "provisional" -> o.lineNo.isEmpty
     ).withoutNulls
   }
 }

--- a/app/uk/gov/hmrc/trusts/models/get_trust_or_estate/get_trust/Trustees.scala
+++ b/app/uk/gov/hmrc/trusts/models/get_trust_or_estate/get_trust/Trustees.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.trusts.models.get_trust_or_estate.get_trust
+
+import play.api.libs.json.{JsNull, JsObject, JsPath, JsValue, Json, Reads}
+
+object Trustees {
+
+  private val pathToTrustees = JsPath \ 'details \ 'trust \ 'entities \ 'trustees
+
+  def transform(response : JsValue) : Reads[JsObject] = {
+    response.transform(pathToTrustees.json.pick).fold(
+      _ => {
+        JsPath.json.pick[JsObject]
+      },
+      trustees => {
+
+        val trusteesUpdated = Json.obj(
+          "trustees" -> trustees.as[List[DisplayTrustTrusteeType]].map {
+            case DisplayTrustTrusteeType(Some(trusteeInd), None) =>
+              Json.obj(
+                "trusteeInd" -> Json.toJson(trusteeInd)(DisplayTrustTrusteeIndividualType.writeToMaintain)
+              )
+            case DisplayTrustTrusteeType(None, Some(trusteeOrg)) =>
+              Json.obj(
+                "trusteeOrg" -> Json.toJson(trusteeOrg)(DisplayTrustTrusteeOrgType.writeToMaintain)
+              )
+            case _ => JsNull
+          }
+        )
+
+        pathToTrustees.json.prune andThen
+          pathToTrustees.json.put(trusteesUpdated)
+      }
+    )
+  }
+
+}

--- a/app/uk/gov/hmrc/trusts/transformers/AddTrusteeCommon.scala
+++ b/app/uk/gov/hmrc/trusts/transformers/AddTrusteeCommon.scala
@@ -36,7 +36,9 @@ trait AddTrusteeCommon {
           val trustees: Reads[JsObject] =
             path.update( of[JsArray]
               .map {
-                trustees => trustees :+ Json.obj(trusteeType.toString -> newTrustee)
+                trustees => trustees :+ Json.obj(
+                  trusteeType.toString -> newTrustee
+                )
               }
             )
           input.transform(trustees)

--- a/app/uk/gov/hmrc/trusts/transformers/AddTrusteeIndTransform.scala
+++ b/app/uk/gov/hmrc/trusts/transformers/AddTrusteeIndTransform.scala
@@ -21,7 +21,11 @@ import uk.gov.hmrc.trusts.models.get_trust_or_estate.get_trust.DisplayTrustTrust
 case class AddTrusteeIndTransform(trustee: DisplayTrustTrusteeIndividualType) extends DeltaTransform with AddTrusteeCommon {
 
   override def applyTransform(input: JsValue): JsResult[JsValue] = {
-    addTrustee(input, Json.toJson(trustee.copy(provisional = Some(true))), TrusteeInd)
+    addTrustee(input, Json.toJson(trustee), TrusteeInd)
+  }
+
+  override def applyDeclarationTransform(input: JsValue): JsResult[JsValue] = {
+    addTrustee(input, Json.toJson(trustee), TrusteeInd)
   }
 }
 

--- a/app/uk/gov/hmrc/trusts/transformers/AddTrusteeIndTransform.scala
+++ b/app/uk/gov/hmrc/trusts/transformers/AddTrusteeIndTransform.scala
@@ -23,10 +23,6 @@ case class AddTrusteeIndTransform(trustee: DisplayTrustTrusteeIndividualType) ex
   override def applyTransform(input: JsValue): JsResult[JsValue] = {
     addTrustee(input, Json.toJson(trustee), TrusteeInd)
   }
-
-  override def applyDeclarationTransform(input: JsValue): JsResult[JsValue] = {
-    addTrustee(input, Json.toJson(trustee), TrusteeInd)
-  }
 }
 
 object AddTrusteeIndTransform {

--- a/app/uk/gov/hmrc/trusts/transformers/PromoteTrusteeCommon.scala
+++ b/app/uk/gov/hmrc/trusts/transformers/PromoteTrusteeCommon.scala
@@ -65,8 +65,7 @@ trait PromoteTrusteeCommon {
           Some(indLead.dateOfBirth),
           Some(indLead.phoneNumber),
           Some(getIdentification(indLead.identification)),
-          indLead.entityStart.get,
-          None
+          indLead.entityStart.get
         )
 
         AddTrusteeIndTransform(demotedTrustee)
@@ -80,8 +79,7 @@ trait PromoteTrusteeCommon {
           Some(orgLead.phoneNumber),
           orgLead.email,
           Some(getIdentification(orgLead.identification)),
-          orgLead.entityStart.get,
-          None
+          orgLead.entityStart.get
         )
 
         AddTrusteeOrgTransform(demotedTrustee)

--- a/app/uk/gov/hmrc/trusts/transformers/RemoveTrusteeTransform.scala
+++ b/app/uk/gov/hmrc/trusts/transformers/RemoveTrusteeTransform.scala
@@ -63,6 +63,7 @@ case class RemoveTrusteeTransform(endDate: LocalDate, index: Int, trusteeToRemov
         case e: JsError => e
       }
     } else {
+      // Do not add the trustee back into the record
       super.applyDeclarationTransform(input)
     }
   }

--- a/app/uk/gov/hmrc/trusts/transformers/mdtp/Trustees.scala
+++ b/app/uk/gov/hmrc/trusts/transformers/mdtp/Trustees.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.trusts.transformers.mdtp
 
 import play.api.libs.json._
@@ -10,7 +26,7 @@ object Trustees {
   def transform(response : JsValue) : Reads[JsObject] = {
     response.transform(pathToTrustees.json.pick).fold(
       _ => {
-        JsPath.json.pick[JsObject]
+        pathToTrustees.json.put(JsArray())
       },
       trustees => {
 

--- a/app/uk/gov/hmrc/trusts/transformers/mdtp/Trustees.scala
+++ b/app/uk/gov/hmrc/trusts/transformers/mdtp/Trustees.scala
@@ -1,22 +1,7 @@
-/*
- * Copyright 2020 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+package uk.gov.hmrc.trusts.transformers.mdtp
 
-package uk.gov.hmrc.trusts.models.get_trust_or_estate.get_trust
-
-import play.api.libs.json.{JsNull, JsObject, JsPath, JsValue, Json, Reads}
+import play.api.libs.json._
+import uk.gov.hmrc.trusts.models.get_trust_or_estate.get_trust.{DisplayTrustTrusteeIndividualType, DisplayTrustTrusteeOrgType, DisplayTrustTrusteeType}
 
 object Trustees {
 

--- a/it/uk/gov/hmrc/repositories/PromoteLeadTrusteeSpec.scala
+++ b/it/uk/gov/hmrc/repositories/PromoteLeadTrusteeSpec.scala
@@ -32,6 +32,7 @@ class PromoteLeadTrusteeSpec extends FreeSpec with MustMatchers with ScalaFuture
   val expectedInitialGetJson: JsValue = JsonUtils.getJsonValueFromFile("trusts-integration-get-initial.json")
 
   "a promote lead trustee call" - {
+
     "must return amended data in a subsequent 'get' call" in {
 
       val newTrusteeIndInfo = DisplayTrustLeadTrusteeIndType(

--- a/it/uk/gov/hmrc/repositories/RemoveTrusteeSpec.scala
+++ b/it/uk/gov/hmrc/repositories/RemoveTrusteeSpec.scala
@@ -94,7 +94,7 @@ class RemoveTrusteeSpec extends FreeSpec with MustMatchers with ScalaFutures wit
               |                  "utr": "5465416546"
               |                },
               |                "entityStart": "1998-02-12",
-              |                "provisional": false
+              |                "provisional": true
               |              }
               |            }
               |]

--- a/it/uk/gov/hmrc/repositories/TransformRepositorySpec.scala
+++ b/it/uk/gov/hmrc/repositories/TransformRepositorySpec.scala
@@ -71,8 +71,7 @@ class TransformRepositorySpec extends FreeSpec with MustMatchers with ScalaFutur
       Some(DateTime.parse("2000-01-01")),
       Some("phoneNumber"),
       Some(DisplayTrustIdentificationType(None, Some("nino"), None, None)),
-      DateTime.parse("2010-10-10"),
-      None
+      DateTime.parse("2010-10-10")
     ))
   )
   )

--- a/test/resources/transformed-get-trust-response.json
+++ b/test/resources/transformed-get-trust-response.json
@@ -219,21 +219,20 @@
                 "safeId": "2222200000000"
               },
               "phoneNumber": "+447456788112",
-              "entityStart": "2017-02-28",
-              "provisional": false
+              "entityStart": "2017-02-28"
             }
           },
           {
             "trusteeOrg": {
               "lineNo": "1",
+              "bpMatchStatus": "01",
               "name": "MyOrg Incorporated",
               "phoneNumber": "+447456788112",
               "email": "a",
               "identification": {
                 "safeId": "2222200000000"
               },
-              "entityStart": "2017-02-28",
-              "provisional": false
+              "entityStart": "2017-02-28"
             }
           }
         ],

--- a/test/resources/trust-transformed-get-api-result.json
+++ b/test/resources/trust-transformed-get-api-result.json
@@ -224,21 +224,20 @@
               "identification": {
                 "safeId": "2222200000000"
               },
-              "entityStart": "2017-02-28",
-              "provisional": false
+              "entityStart": "2017-02-28"
             }
           },
           {
             "trusteeOrg": {
               "lineNo": "1",
+              "bpMatchStatus": "01",
               "name": "MyOrg Incorporated",
               "phoneNumber": "+447456788112",
               "email": "a",
               "identification": {
                 "safeId": "2222200000000"
               },
-              "entityStart": "2017-02-28",
-              "provisional": false
+              "entityStart": "2017-02-28"
             }
           }
         ],

--- a/test/resources/trust-transformed-get-trustees-result.json
+++ b/test/resources/trust-transformed-get-trustees-result.json
@@ -15,7 +15,7 @@
         },
         "phoneNumber": "+447456788112",
         "entityStart": "2017-02-28",
-        "provisional": true
+        "provisional": false
       }
     },
     {
@@ -29,7 +29,7 @@
           "safeId": "2222200000000"
         },
         "entityStart": "2017-02-28",
-        "provisional": true
+        "provisional": false
       }
     }
   ]

--- a/test/resources/trust-transformed-get-trustees-result.json
+++ b/test/resources/trust-transformed-get-trustees-result.json
@@ -15,12 +15,13 @@
         },
         "phoneNumber": "+447456788112",
         "entityStart": "2017-02-28",
-        "provisional": false
+        "provisional": true
       }
     },
     {
       "trusteeOrg": {
         "lineNo": "1",
+        "bpMatchStatus": "01",
         "name": "MyOrg Incorporated",
         "phoneNumber": "+447456788112",
         "email": "a",
@@ -28,7 +29,7 @@
           "safeId": "2222200000000"
         },
         "entityStart": "2017-02-28",
-        "provisional": false
+        "provisional": true
       }
     }
   ]

--- a/test/resources/trusts-etmp-get-trust-add-ind-trustee.json
+++ b/test/resources/trusts-etmp-get-trust-add-ind-trustee.json
@@ -175,8 +175,7 @@
               "identification":{
                 "nino":"nino"
               },
-              "entityStart":"1990-10-10",
-              "provisional": true
+              "entityStart":"1990-10-10"
             }
           }
         ],

--- a/test/resources/trusts-etmp-get-trust-add-org-trustee.json
+++ b/test/resources/trusts-etmp-get-trust-add-org-trustee.json
@@ -167,8 +167,7 @@
           {
             "trusteeOrg": {
               "name": "Company Name",
-              "entityStart": "2020-01-30",
-              "provisional": true
+              "entityStart": "2020-01-30"
             }
           }
         ],

--- a/test/resources/trusts-etmp-get-trust-trustees-after-add.json
+++ b/test/resources/trusts-etmp-get-trust-trustees-after-add.json
@@ -181,8 +181,7 @@
               "identification":{
                 "nino":"nino"
               },
-              "entityStart":"1990-10-10",
-              "provisional": true
+              "entityStart":"1990-10-10"
             }
           }
         ]

--- a/test/resources/trusts-etmp-get-trust-trustees-after-org-add.json
+++ b/test/resources/trusts-etmp-get-trust-trustees-after-org-add.json
@@ -173,8 +173,7 @@
           {
             "trusteeOrg":{
               "name": "Company Name",
-              "entityStart":"2020-01-30",
-              "provisional": true
+              "entityStart":"2020-01-30"
             }
           }
         ]

--- a/test/resources/trusts-integration-get-after-promote-trustee.json
+++ b/test/resources/trusts-integration-get-after-promote-trustee.json
@@ -158,8 +158,7 @@
               "identification": {
                 "utr": "5465416546"
               },
-              "entityStart": "1998-02-12",
-              "provisional": true
+              "entityStart": "1998-02-12"
             }
           }
         ],

--- a/test/resources/trusts-promote-trustee-transform-after-ind-declare.json
+++ b/test/resources/trusts-promote-trustee-transform-after-ind-declare.json
@@ -53,8 +53,7 @@
               "identification":{
                 "nino":"Nino"
               },
-              "entityStart":"1998-02-12",
-              "provisional": true
+              "entityStart":"1998-02-12"
             }
           },
           {

--- a/test/resources/trusts-promote-trustee-transform-after-ind.json
+++ b/test/resources/trusts-promote-trustee-transform-after-ind.json
@@ -53,8 +53,7 @@
               "identification":{
                 "nino":"Nino"
               },
-              "entityStart":"1998-02-12",
-              "provisional": true
+              "entityStart":"1998-02-12"
             }
           }
         ]

--- a/test/resources/trusts-promote-trustee-transform-after-org.json
+++ b/test/resources/trusts-promote-trustee-transform-after-org.json
@@ -51,8 +51,7 @@
               "identification":{
                 "nino":"Nino"
               },
-              "entityStart":"1998-02-12",
-              "provisional": true
+              "entityStart":"1998-02-12"
             }
           }
         ]

--- a/test/uk/gov/hmrc/trusts/controllers/TransformationControllerSpec.scala
+++ b/test/uk/gov/hmrc/trusts/controllers/TransformationControllerSpec.scala
@@ -99,8 +99,7 @@ class TransformationControllerSpec extends FreeSpec with MockitoSugar with Scala
         dateOfBirth = Some(new DateTime(1965, 2, 10, 0, 0)),
         phoneNumber = Some("newPhone"),
         identification = Some(DisplayTrustIdentificationType(None, Some("newNino"), None, None)),
-        entityStart = DateTime.parse("2012-03-14"),
-        None
+        entityStart = DateTime.parse("2012-03-14")
       )
 
       when(transformationService.addAddTrusteeTransformer(any(), any(), any()))

--- a/test/uk/gov/hmrc/trusts/services/TransformationServiceSpec.scala
+++ b/test/uk/gov/hmrc/trusts/services/TransformationServiceSpec.scala
@@ -67,8 +67,7 @@ class TransformationServiceSpec extends FreeSpec with MockitoSugar with ScalaFut
     dateOfBirth = Some(new DateTime(1965, 2, 10, 12, 30)),
     phoneNumber = Some("newPhone"),
     identification = Some(DisplayTrustIdentificationType(None, Some("newNino"), None, None)),
-    entityStart = DateTime.parse("2012-03-14"),
-    None
+    entityStart = DateTime.parse("2012-03-14")
   )
 
   val newTrusteeOrgInfo = DisplayTrustTrusteeOrgType(
@@ -82,8 +81,7 @@ class TransformationServiceSpec extends FreeSpec with MockitoSugar with ScalaFut
       Some("newUtr"),
       None)
     ),
-    entityStart = DateTime.parse("2012-03-14"),
-    provisional = None
+    entityStart = DateTime.parse("2012-03-14")
   )
 
   val existingLeadTrusteeInfo = DisplayTrustLeadTrusteeIndType(
@@ -115,8 +113,7 @@ class TransformationServiceSpec extends FreeSpec with MockitoSugar with ScalaFut
     dateOfBirth = Some(DateTime.parse("1956-02-12")),
     phoneNumber = Some("0121546546"),
     identification = Some(DisplayTrustIdentificationType(None, Some("ST123456"), None, None)),
-    entityStart = DateTime.parse("1998-02-12"),
-    None
+    entityStart = DateTime.parse("1998-02-12")
   )
 
   private val auditService = mock[AuditService]

--- a/test/uk/gov/hmrc/trusts/transformers/AddTrusteeIndTransformSpec.scala
+++ b/test/uk/gov/hmrc/trusts/transformers/AddTrusteeIndTransformSpec.scala
@@ -33,8 +33,7 @@ class AddTrusteeIndTransformSpec extends FreeSpec with MustMatchers with OptionV
         Some(DateTime.parse("2000-01-01")),
         Some("phoneNumber"),
         Some(DisplayTrustIdentificationType(None, Some("nino"), None, None)),
-        DateTime.parse("1990-10-10"),
-        None
+        DateTime.parse("1990-10-10")
       )
 
       val trustJson = JsonUtils.getJsonValueFromFile("trusts-etmp-get-trust-no-trustees.json")
@@ -56,8 +55,7 @@ class AddTrusteeIndTransformSpec extends FreeSpec with MustMatchers with OptionV
         Some(DateTime.parse("2000-01-01")),
         Some("phoneNumber"),
         Some(DisplayTrustIdentificationType(None, Some("nino"), None, None)),
-        DateTime.parse("1990-10-10"),
-        None
+        DateTime.parse("1990-10-10")
       )
 
       val trustJson = JsonUtils.getJsonValueFromFile("trusts-etmp-get-trust-cached.json")
@@ -79,8 +77,7 @@ class AddTrusteeIndTransformSpec extends FreeSpec with MustMatchers with OptionV
         Some(DateTime.parse("2000-01-01")),
         Some("phoneNumber"),
         Some(DisplayTrustIdentificationType(None, Some("nino"), None, None)),
-        DateTime.parse("1990-10-10"),
-        None
+        DateTime.parse("1990-10-10")
       )
 
       val json = JsonUtils.getJsonValueFromFile("trusts-etmp-max-trustees.json")

--- a/test/uk/gov/hmrc/trusts/transformers/AddTrusteeOrgTransformSpec.scala
+++ b/test/uk/gov/hmrc/trusts/transformers/AddTrusteeOrgTransformSpec.scala
@@ -32,8 +32,7 @@ class AddTrusteeOrgTransformSpec extends FreeSpec with MustMatchers with OptionV
         None,
         None,
         None,
-        DateTime.parse("2020-01-30"),
-        None
+        DateTime.parse("2020-01-30")
       )
 
       val trustJson = JsonUtils.getJsonValueFromFile("trusts-etmp-get-trust-no-trustees.json")
@@ -56,8 +55,7 @@ class AddTrusteeOrgTransformSpec extends FreeSpec with MustMatchers with OptionV
         None,
         None,
         None,
-        DateTime.parse("2020-01-30"),
-        Some(true)
+        DateTime.parse("2020-01-30")
       )
 
       val trustJson = JsonUtils.getJsonValueFromFile("trusts-etmp-get-trust-cached.json")
@@ -84,8 +82,7 @@ class AddTrusteeOrgTransformSpec extends FreeSpec with MustMatchers with OptionV
           Some("utr"),
           None
         )),
-        DateTime.parse("1990-10-10"),
-        Some(true)
+        DateTime.parse("1990-10-10")
       )
 
       val json = JsonUtils.getJsonValueFromFile("trusts-etmp-max-trustees.json")

--- a/test/uk/gov/hmrc/trusts/transformers/DeltaTransformSpec.scala
+++ b/test/uk/gov/hmrc/trusts/transformers/DeltaTransformSpec.scala
@@ -51,8 +51,7 @@ class DeltaTransformSpec extends FreeSpec with MustMatchers with OptionValues {
           Some(DateTime.parse("2000-01-01")),
           Some("phoneNumber"),
           Some(DisplayTrustIdentificationType(None, Some("nino"), None, None)),
-          DateTime.parse("2000-01-01"),
-          None
+          DateTime.parse("2000-01-01")
         ))
 
       val removeTrusteeTransform = RemoveTrusteeTransform(

--- a/test/uk/gov/hmrc/trusts/transformers/PromoteTrusteeIndTransformSpec.scala
+++ b/test/uk/gov/hmrc/trusts/transformers/PromoteTrusteeIndTransformSpec.scala
@@ -47,6 +47,7 @@ class PromoteTrusteeIndTransformSpec extends FreeSpec with MustMatchers with Opt
       |""".stripMargin)
 
   "the promote trustee ind transformer should" - {
+
     "successfully promote a trustee to lead and demote the existing lead trustee" in {
       val beforeJson = JsonUtils.getJsonValueFromFile("trusts-promote-trustee-transform-before-ind.json")
       val afterJson = JsonUtils.getJsonValueFromFile("trusts-promote-trustee-transform-after-ind.json")


### PR DESCRIPTION
1. Trustee model no longer has a concern for a provisonal flag
2. Flag is no longer set in the transformers or written to the ETMP document
3. Flag is set through an explicit JSON writes at the point the api returns a response for GET /trust/trustees
4. I have tested this and it submits the declaration now