### PR TITLE
Making property previous value optional on playback and variation

### DIFF
--- a/app/uk/gov/hmrc/trusts/models/TrustRegistrationModels.scala
+++ b/app/uk/gov/hmrc/trusts/models/TrustRegistrationModels.scala
@@ -390,8 +390,6 @@ object NonUKType {
   implicit val nonUKTypeFormat: Format[NonUKType] = Json.format[NonUKType]
 }
 
-
-
 case class PropertyLandType(buildingLandName: Option[String],
                             address: Option[AddressType],
                             valueFull: Long,

--- a/app/uk/gov/hmrc/trusts/models/get_trust_or_estate/get_trust/GetTrustSchemaModels.scala
+++ b/app/uk/gov/hmrc/trusts/models/get_trust_or_estate/get_trust/GetTrustSchemaModels.scala
@@ -598,6 +598,15 @@ object DisplayTrustAssets {
   implicit val assetsFormat: Format[DisplayTrustAssets] = Json.format[DisplayTrustAssets]
 }
 
+case class PropertyLandType(buildingLandName: Option[String],
+                            address: Option[AddressType],
+                            valueFull: Long,
+                            valuePrevious: Option[Long])
+
+object PropertyLandType {
+  implicit val propertyLandTypeFormat: Format[PropertyLandType] = Json.format[PropertyLandType]
+}
+
 case class DisplaySharesType(numberOfShares: Option[String],
                              orgName: String,
                              utr: Option[String],

--- a/app/uk/gov/hmrc/trusts/models/variation/TrustVariationModels.scala
+++ b/app/uk/gov/hmrc/trusts/models/variation/TrustVariationModels.scala
@@ -412,6 +412,15 @@ object Assets {
   implicit val assetsFormat: Format[Assets] = Json.format[Assets]
 }
 
+case class PropertyLandType(buildingLandName: Option[String],
+                            address: Option[AddressType],
+                            valueFull: Long,
+                            valuePrevious: Option[Long])
+
+object PropertyLandType {
+  implicit val propertyLandTypeFormat: Format[PropertyLandType] = Json.format[PropertyLandType]
+}
+
 case class SharesType(
                        numberOfShares: Option[String],
                        orgName: String,

--- a/test/resources/valid-get-trust-response-property-or-land-no-previous-value.json
+++ b/test/resources/valid-get-trust-response-property-or-land-no-previous-value.json
@@ -1,0 +1,369 @@
+{
+  "responseHeader": {
+    "dfmcaReturnUserStatus": "Processed",
+    "formBundleNo": "1"
+  },
+  "trustOrEstateDisplay": {
+    "applicationType": "01",
+    "matchData": {
+      "utr": "2134514321"
+    },
+    "correspondence": {
+      "abroadIndicator": true,
+      "name": "Nelson James",
+      "address": {
+        "line1": "1010 EASY ST",
+        "line2": "OTTAWA",
+        "line3": "ONTARIO",
+        "line4": "ONTARIO",
+        "postCode": "K1A 0B1",
+        "country": "GB"
+      },
+      "phoneNumber": "+10392019203"
+    },
+    "declaration": {
+      "name": {
+        "firstName": "Nelson",
+        "middleName": "Nicola",
+        "lastName": "James"
+      },
+      "address": {
+        "line1": "1010 EASY ST",
+        "line2": "OTTAWA",
+        "line3": "ONTARIO",
+        "line4": "ONTARIO",
+        "postCode": "K1A 0B1",
+        "country": "GB"
+      }
+    },
+    "details": {
+      "trust": {
+        "details": {
+          "startDate": "1920-03-28",
+          "lawCountry": "AD",
+          "administrationCountry": "GB",
+          "residentialStatus": {
+            "uk": {
+              "scottishLaw": false,
+              "preOffShore": "GB"
+            }
+          },
+          "typeOfTrust": "Will Trust or Intestacy Trust",
+          "deedOfVariation": "Previously there was only an absolute interest under the will",
+          "interVivos": true,
+          "efrbsStartDate": "1920-02-28"
+        },
+        "entities": {
+          "naturalPerson": [
+            {
+              "lineNo": "1",
+              "bpMatchStatus": "01",
+              "name": {
+                "firstName": "Nicola",
+                "middleName": "Andrey",
+                "lastName": "Jackson"
+              },
+              "dateOfBirth": "1970-02-28",
+              "identification": {
+                "safeId": "2222200000000"
+              },
+              "entityStart": "2017-02-28"
+            }
+          ],
+          "beneficiary": {
+            "individualDetails": [
+              {
+                "lineNo": "1",
+                "bpMatchStatus": "01",
+                "name": {
+                  "firstName": "Nicola",
+                  "middleName": "Andrey",
+                  "lastName": "Jackson"
+                },
+                "dateOfBirth": "1970-02-28",
+                "vulnerableBeneficiary": true,
+                "beneficiaryType": "Director",
+                "beneficiaryDiscretion": true,
+                "beneficiaryShareOfIncome": "0",
+                "identification": {
+                  "safeId": "2222200000000"
+                },
+                "entityStart": "2017-02-28"
+              }
+            ],
+            "company": [
+              {
+                "lineNo": "1",
+                "bpMatchStatus": "01",
+                "organisationName": " ",
+                "beneficiaryDiscretion": true,
+                "beneficiaryShareOfIncome": "0",
+                "identification": {
+                  "safeId": "2222200000000"
+                },
+                "entityStart": "2017-02-28"
+              }
+            ],
+            "trust": [
+              {
+                "lineNo": "1",
+                "bpMatchStatus": "01",
+                "organisationName": "Nelson Ltd ",
+                "beneficiaryDiscretion": true,
+                "beneficiaryShareOfIncome": "0",
+                "identification": {
+                  "safeId": "2222200000000"
+                },
+                "entityStart": "2017-02-28"
+              }
+            ],
+            "charity": [
+              {
+                "lineNo": "1",
+                "bpMatchStatus": "01",
+                "organisationName": "Nelson Ltd",
+                "beneficiaryDiscretion": true,
+                "beneficiaryShareOfIncome": "0",
+                "identification": {
+                  "safeId": "2222200000000"
+                },
+                "entityStart": "2017-02-28"
+              }
+            ],
+            "unidentified": [
+              {
+                "lineNo": "1",
+                "bpMatchStatus": "01",
+                "description": "Reserve money",
+                "beneficiaryDiscretion": true,
+                "beneficiaryShareOfIncome": "0",
+                "entityStart": "2017-02-28"
+              }
+            ],
+            "large": [
+              {
+                "lineNo": "1",
+                "bpMatchStatus": "01",
+                "organisationName": "Nelson Ltd",
+                "description": "This is a must",
+                "description1": "This is a must",
+                "description2": "This is a must",
+                "description3": "This is a must",
+                "description4": "This is a must",
+                "numberOfBeneficiary": "0",
+                "identification": {
+                  "safeId": "2222200000000"
+                },
+                "beneficiaryDiscretion": true,
+                "beneficiaryShareOfIncome": "0",
+                "entityStart": "2017-02-28"
+              }
+            ],
+            "other": [
+              {
+                "lineNo": "1",
+                "bpMatchStatus": "01",
+                "description": "Joint Fund",
+                "address": {
+                  "line1": "1010 EASY ST",
+                  "line2": "OTTAWA",
+                  "line3": "ONTARIO",
+                  "line4": "ONTARIO",
+                  "postCode": "K1A 0B1",
+                  "country": "GB"
+                },
+                "beneficiaryDiscretion": true,
+                "beneficiaryShareOfIncome": "0",
+                "entityStart": "2017-02-28"
+              }
+            ]
+          },
+          "deceased": {
+            "lineNo": "1",
+            "bpMatchStatus": "01",
+            "name": {
+              "firstName": "James",
+              "middleName": "Kingsley",
+              "lastName": "Bond"
+            },
+            "dateOfBirth": "1965-02-28",
+            "dateOfDeath": "2018-02-28",
+            "identification": {
+              "safeId": "2222200000000"
+            },
+            "entityStart": "2017-02-28"
+          },
+          "leadTrustees": {
+              "lineNo": "1",
+              "bpMatchStatus": "01",
+              "name": {
+                "firstName": "Jimmy",
+                "middleName": "Hingis",
+                "lastName": "Jones"
+              },
+              "dateOfBirth": "1965-02-28",
+              "phoneNumber": "+1234567",
+              "email": "a",
+              "identification": {
+                "nino": "NH111111A"
+              },
+              "entityStart": "2017-02-28"
+          },
+          "trustees": [
+            {
+              "trusteeInd": {
+                "lineNo": "1",
+                "bpMatchStatus": "01",
+                "name": {
+                  "firstName": "Tamara",
+                  "middleName": "Hingis",
+                  "lastName": "Jones"
+                },
+                "dateOfBirth": "1965-02-28",
+                "identification": {
+                  "safeId": "2222200000000"
+                },
+                "phoneNumber": "+447456788112",
+                "entityStart": "2017-02-28"
+              }
+            },
+            {
+              "trusteeOrg": {
+                "lineNo": "1",
+                "name": "MyOrg Incorporated",
+                "phoneNumber": "+447456788112",
+                "email": "a",
+                "identification": {
+                  "safeId": "2222200000000"
+                },
+                "entityStart": "2017-02-28"
+              }
+            }
+          ],
+          "protectors": {
+            "protector": [
+              {
+                "lineNo": "1",
+                "bpMatchStatus": "01",
+                "name": {
+                  "firstName": "Bruce",
+                  "middleName": "Bob",
+                  "lastName": "Branson"
+                },
+                "dateOfBirth": "1965-02-28",
+                "identification": {
+                  "safeId": "2222200000000"
+                },
+                "entityStart": "2017-02-28"
+              }
+            ],
+            "protectorCompany": [
+              {
+                "lineNo": "1",
+                "bpMatchStatus": "01",
+                "name": "Raga Dandy",
+                "identification": {
+                  "safeId": "2222200000000"
+                },
+                "entityStart": "2017-02-28"
+              }
+            ]
+          },
+          "settlors": {
+            "settlor": [
+              {
+                "lineNo": "1",
+                "bpMatchStatus": "01",
+                "name": {
+                  "firstName": "Bruce",
+                  "middleName": "Bob",
+                  "lastName": "Branson"
+                },
+                "dateOfBirth": "1965-02-28",
+                "identification": {
+                  "safeId": "2222200000000"
+                },
+                "entityStart": "2017-02-28"
+              }
+            ],
+            "settlorCompany": [
+              {
+                "lineNo": "1",
+                "bpMatchStatus": "01",
+                "name": "Completors Limited ",
+                "companyType": "Trading",
+                "companyTime": true,
+                "identification": {
+                  "safeId": "2222200000000"
+                },
+                "entityStart": "2017-02-28"
+              }
+            ]
+          }
+        },
+        "assets": {
+          "monetary": [
+            {
+              "assetMonetaryAmount": 0
+            }
+          ],
+          "propertyOrLand": [
+            {
+              "buildingLandName": "Tokyo Campus",
+              "address": {
+                "line1": "10 Enderson Road ",
+                "line2": "Cheapside",
+                "line3": "Riverside ",
+                "line4": "Boston ",
+                "postCode": "SN8 4DD",
+                "country": "GB"
+              },
+              "valueFull": 1892090
+            }
+          ],
+          "shares": [
+            {
+              "numberOfShares": "0",
+              "orgName": "Smart Estates",
+              "utr": "2134514321",
+              "shareClass": "Ordinary shares",
+              "typeOfShare": "Quoted",
+              "value": 9891828
+            }
+          ],
+          "business": [
+            {
+              "orgName": "Lone Wolf Ltd",
+              "utr": "2134514322",
+              "businessDescription": "Travel Business",
+              "address": {
+                "line1": "Suite 10",
+                "line2": "Wealthy Arena",
+                "line3": "Trafagar Square ",
+                "line4": "London",
+                "postCode": "SE2 2HB",
+                "country": "GB"
+              },
+              "businessValue": 0
+            }
+          ],
+          "partnerShip": [
+            {
+              "utr": "2134514321",
+              "description": "Real Estates partnership",
+              "partnershipStart": "2010-02-28"
+            }
+          ],
+          "other": [
+            {
+              "description": "Jewelries",
+              "value": 781720
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+
+

--- a/test/resources/valid-trusts-variations-no-previous-value-property-api.json
+++ b/test/resources/valid-trusts-variations-no-previous-value-property-api.json
@@ -1,0 +1,240 @@
+{
+  "matchData": {
+    "utr": "5465416546"
+  },
+  "correspondence": {
+    "abroadIndicator": false,
+    "name": "Abram James",
+    "address": {
+      "line1": "1344 Army Road",
+      "line2": "Suite 111",
+      "line3": "Telford",
+      "line4": "Shropshire",
+      "postCode": "TF1 5DR",
+      "country": "GB"
+    },
+    "phoneNumber": "+4423400342"
+  },
+  "declaration": {
+    "name": {
+      "firstName": "Abram",
+      "middleName": "Joe",
+      "lastName": "James"
+    },
+    "address": {
+      "line1": "1344 Army Road",
+      "line2": "Suite 111",
+      "line3": "Telford",
+      "line4": "Shropshire",
+      "postCode": "TF1 5DR",
+      "country": "GB"
+    }
+  },
+  "details": {
+    "trust": {
+      "details": {
+        "startDate": "2001-01-01",
+        "administrationCountry": "GB",
+        "residentialStatus": {
+          "uk": {
+            "scottishLaw": false,
+            "preOffShore": "AD"
+          }
+        },
+        "typeOfTrust": "Will Trust or Intestacy Trust",
+        "deedOfVariation": "Previously there was only an absolute interest under the will",
+        "interVivos": false,
+        "efrbsStartDate": "2001-01-01"
+      },
+      "entities": {
+        "naturalPerson": [
+          {
+            "name": {
+              "firstName": "John",
+              "middleName": "William",
+              "lastName": "O'Connor"
+            },
+            "dateOfBirth": "1956-02-12",
+            "identification": {
+              "nino": "KC287812"
+            },
+            "entityStart": "1998-02-12"
+          }
+        ],
+        "beneficiary": {
+          "individualDetails": [
+            {
+              "name": {
+                "firstName": "John",
+                "middleName": "William",
+                "lastName": "O'Connor"
+              },
+              "dateOfBirth": "2001-01-01",
+              "vulnerableBeneficiary": true,
+              "beneficiaryType": "Director",
+              "beneficiaryDiscretion": true,
+              "beneficiaryShareOfIncome": "100",
+              "identification": {
+                "passport": {
+                  "number": "abcdefgh",
+                  "expirationDate": "2001-01-01",
+                  "countryOfIssue": "GB"
+                },
+                "address": {
+                  "line1": "1344 Army Road",
+                  "line2": "Suite 111",
+                  "line4": "Telford",
+                  "postCode": "TF1 5DR",
+                  "country": "GB"
+                }
+              },
+              "entityStart": "1998-02-12"
+            }
+          ],
+          "other": [
+            {
+              "address": {
+                "line1": "1344 Army Road",
+                "line2": "Suite 111",
+                "line4": "Telford",
+                "postCode": "TF1 5DR",
+                "country": "GB"
+              },
+              "description": "Lorem ipsum",
+              "entityStart": "1998-02-12"
+            }
+          ]
+        },
+        "deceased": {
+          "name": {
+            "firstName": "John",
+            "middleName": "William",
+            "lastName": "O'Connor"
+          },
+          "dateOfBirth": "1956-02-12",
+          "dateOfDeath": "2016-01-01",
+          "identification": {
+            "nino": "KC456736"
+          },
+          "entityStart": "1998-02-12"
+        },
+        "leadTrustees": [
+          {
+            "leadTrusteeOrg": {
+              "name": "Trust Services LTD",
+              "phoneNumber": "0754545454",
+              "email": "me@you.com",
+              "identification": {
+                "utr": "5465416546"
+              },
+              "entityStart": "1998-02-12"
+            }
+          }
+        ],
+        "trustees": [
+          {
+            "trusteeInd": {
+              "name": {
+                "firstName": "John",
+                "middleName": "William",
+                "lastName": "O'Connor"
+              },
+              "dateOfBirth": "1956-02-12",
+              "identification": {
+                "nino": "ST123456"
+              },
+              "phoneNumber": "0121546546",
+              "entityStart": "1998-02-12"
+            }
+          }
+        ],
+        "settlors": {
+          "settlor": [
+            {
+              "name": {
+                "firstName": "abcdefghijkl",
+                "middleName": "abcdefghijklmn",
+                "lastName": "abcde"
+              },
+              "dateOfBirth": "2001-01-01",
+              "identification": {
+                "nino": "ST019091"
+              },
+              "entityStart": "1998-02-12"
+            }
+          ],
+          "settlorCompany": [
+            {
+              "name": "abcdefghijklmnopqr",
+              "companyType": "Trading",
+              "companyTime": false,
+              "identification": {
+                "utr": "5465416546"
+              },
+              "entityStart": "1998-02-12"
+            }
+          ]
+        }
+      },
+      "assets": {
+        "monetary": [
+          {
+            "assetMonetaryAmount": 100000
+          }
+        ],
+        "propertyOrLand": [
+          {
+            "buildingLandName": "ACB House",
+            "address": {
+              "line1": "1344 Army Road",
+              "line2": "Suite 111",
+              "line4": "Telford",
+              "postCode": "TF1 5DR",
+              "country": "GB"
+            },
+            "valueFull": 1000000
+          }
+        ],
+        "shares": [
+          {
+            "numberOfShares": "100",
+            "orgName": "Mock Org LTD",
+            "utr": "5465416546",
+            "shareClass": "Ordinary shares",
+            "typeOfShare": "Quoted",
+            "value": 4584545
+          }
+        ],
+        "partnerShip": [
+          {
+            "utr": "5456456221",
+            "description": "Partnership Trade",
+            "partnershipStart": "2001-01-01"
+          }
+        ],
+        "other": [
+          {
+            "description": "Lorem ipsum anum",
+            "value": 1982372
+          }
+        ]
+      }
+    }
+  },
+  "agentDetails": {
+    "arn": "AARN1234567",
+    "agentName": "Mr. xys abcde",
+    "agentAddress": {
+      "line1": "line1",
+      "line2": "line2",
+      "postCode": "TF3 2BX",
+      "country": "GB"
+    },
+    "agentTelephoneNumber": "07912180120",
+    "clientReference": "clientReference"
+  },
+  "trustEndDate": "1520-02-29",
+  "reqHeader": {
+    "formBundleNo": "ABCD12387218"
+  }
+}

--- a/test/uk/gov/hmrc/trusts/utils/JsonRequests.scala
+++ b/test/uk/gov/hmrc/trusts/utils/JsonRequests.scala
@@ -38,6 +38,9 @@ trait JsonRequests extends JsonUtils {
   lazy val invalidEstateVariationsRequestJson: String = getJsonFromFile("invalid-estate-variation-api.json")
 
   lazy val trustVariationsRequest: JsValue = getJsonValueFromFile("valid-trusts-variations-api.json").validate[JsValue].get
+
+  lazy val trustVariationsNoPreviousPropertyValueRequest: JsValue = getJsonValueFromFile("valid-trusts-variations-no-previous-value-property-api.json").validate[JsValue].get
+
   lazy val invalidTrustVariationsRequest: JsValue = getJsonValueFromFile("invalid-payload-trusts-variations.json")
 
   lazy val estateVariationsRequest: EstateVariation = getJsonValueFromFile("valid-estate-variation-api.json").validate[EstateVariation].get
@@ -48,6 +51,10 @@ trait JsonRequests extends JsonUtils {
 
   lazy val getTrustResponseJson: String = getJsonFromFile("valid-get-trust-response.json")
   lazy val getTrustResponse: JsValue = getJsonValueFromFile("valid-get-trust-response.json")
+
+  lazy val getTrustPropertyLandNoPreviousValue: String = getJsonFromFile("valid-get-trust-response-property-or-land-no-previous-value.json")
+  lazy val getTrustPropertyLandNoPreviousValueJson: JsValue = getJsonValueFromFile("valid-get-trust-response-property-or-land-no-previous-value.json")
+
   lazy val getTransformedTrustResponse: JsValue = getJsonValueFromFile("transformed-get-trust-response.json")
   lazy val getEmptyTransformedTrustResponse: JsValue = getJsonValueFromFile("empty-transformed-get-trust-response.json")
   lazy val getTransformedApiResponse: JsValue = getJsonValueFromFile("trust-transformed-get-api-result.json")


### PR DESCRIPTION
The PropertyOrLandAssetType was shared with registration models where previousValue was mandatory.

This was extracted out to no longer be shared.