### PR TITLE
[TRUS-3183] - Enrolling a Lead Trustee after registering a non-taxable trust

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -39,12 +39,12 @@ class AppConfig @Inject()(configuration: Configuration, servicesConfig: Services
 
   private def insertTRN(url: String, trn: String) = url.replace(":trn", trn)
 
-  val taxEnrolmentsPayloadBodyServiceName : String =
-    configuration.get[String]("microservice.services.tax-enrolments.serviceName")
+  val taxEnrolmentsPayloadBodyServiceNameTaxable : String =
+    configuration.get[String]("microservice.services.tax-enrolments.taxable.serviceName")
 
-  val taxEnrolmentsPayloadBodyCallbackTemplate : String =
-    configuration.get[String]("microservice.services.tax-enrolments.callback")
-  def taxEnrolmentsPayloadBodyCallback(trn: String): String = insertTRN(taxEnrolmentsPayloadBodyCallbackTemplate, trn)
+  val taxEnrolmentsPayloadBodyCallbackTaxableTemplate : String =
+    configuration.get[String]("microservice.services.tax-enrolments.taxable.callback")
+  def taxEnrolmentsPayloadBodyCallbackTaxable(trn: String): String = insertTRN(taxEnrolmentsPayloadBodyCallbackTaxableTemplate, trn)
 
   val taxEnrolmentsPayloadBodyServiceNameNonTaxable: String =
     configuration.get[String]("microservice.services.tax-enrolments.non-taxable.serviceName")

--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -42,15 +42,17 @@ class AppConfig @Inject()(configuration: Configuration, servicesConfig: Services
   val taxEnrolmentsPayloadBodyServiceNameTaxable : String =
     configuration.get[String]("microservice.services.tax-enrolments.taxable.serviceName")
 
-  val taxEnrolmentsPayloadBodyCallbackTaxableTemplate : String =
+  private val taxEnrolmentsPayloadBodyCallbackTaxableTemplate : String =
     configuration.get[String]("microservice.services.tax-enrolments.taxable.callback")
+
   def taxEnrolmentsPayloadBodyCallbackTaxable(trn: String): String = insertTRN(taxEnrolmentsPayloadBodyCallbackTaxableTemplate, trn)
 
   val taxEnrolmentsPayloadBodyServiceNameNonTaxable: String =
     configuration.get[String]("microservice.services.tax-enrolments.non-taxable.serviceName")
 
-  val taxEnrolmentsPayloadBodyCallbackNonTaxableTemplate : String =
+  private val taxEnrolmentsPayloadBodyCallbackNonTaxableTemplate : String =
     configuration.get[String]("microservice.services.tax-enrolments.non-taxable.callback")
+
   def taxEnrolmentsPayloadBodyCallbackNonTaxable(trn: String): String = insertTRN(taxEnrolmentsPayloadBodyCallbackNonTaxableTemplate, trn)
 
   val delayToConnectTaxEnrolment : Int =

--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -37,14 +37,21 @@ class AppConfig @Inject()(configuration: Configuration, servicesConfig: Services
   val variationsApiSchema4MLD: String = "/resources/schemas/4MLD/variations-api-schema-4.0.json"
   val variationsApiSchema5MLD: String = "/resources/schemas/5MLD/variations-api-schema-4.2.0.json"
 
+  private def insertTRN(url: String, trn: String) = url.replace(":trn", trn)
+
   val taxEnrolmentsPayloadBodyServiceName : String =
     configuration.get[String]("microservice.services.tax-enrolments.serviceName")
 
-  val taxEnrolmentsPayloadBodyServiceName5MLD: String =
-    configuration.get[String]("microservice.services.tax-enrolments.serviceName5MLD")
-
-  val taxEnrolmentsPayloadBodyCallback : String =
+  val taxEnrolmentsPayloadBodyCallbackTemplate : String =
     configuration.get[String]("microservice.services.tax-enrolments.callback")
+  def taxEnrolmentsPayloadBodyCallback(trn: String): String = insertTRN(taxEnrolmentsPayloadBodyCallbackTemplate, trn)
+
+  val taxEnrolmentsPayloadBodyServiceNameNonTaxable: String =
+    configuration.get[String]("microservice.services.tax-enrolments.non-taxable.serviceName")
+
+  val taxEnrolmentsPayloadBodyCallbackNonTaxableTemplate : String =
+    configuration.get[String]("microservice.services.tax-enrolments.non-taxable.callback")
+  def taxEnrolmentsPayloadBodyCallbackNonTaxable(trn: String): String = insertTRN(taxEnrolmentsPayloadBodyCallbackNonTaxableTemplate, trn)
 
   val delayToConnectTaxEnrolment : Int =
     configuration.get[String]("microservice.services.trusts.delayToConnectTaxEnrolment").toInt

--- a/app/connector/TaxEnrolmentConnector.scala
+++ b/app/connector/TaxEnrolmentConnector.scala
@@ -44,7 +44,7 @@ class TaxEnrolmentConnectorImpl @Inject()(http: HttpClient,
     case _ => config.taxEnrolmentsPayloadBodyServiceName
   }
 
-  def getResponse(subscriptionId: String, serviceName: String)(implicit hc: HeaderCarrier) :  Future[TaxEnrolmentSuscriberResponse] = {
+  def getResponse(subscriptionId: String, serviceName: String, taxable: Boolean)(implicit hc: HeaderCarrier) :  Future[TaxEnrolmentSuscriberResponse] = {
     val taxEnrolmentsEndpoint = s"${config.taxEnrolmentsUrl}/tax-enrolments/subscriptions/$subscriptionId/subscriber"
     val taxEnrolmentHeaders = hc.withExtraHeaders(headers: _*)
 
@@ -57,10 +57,10 @@ class TaxEnrolmentConnectorImpl @Inject()(http: HttpClient,
     response
   }
 
-  override  def enrolSubscriber(subscriptionId: String)(implicit hc: HeaderCarrier) :  Future[TaxEnrolmentSuscriberResponse] = {
+  override  def enrolSubscriber(subscriptionId: String, taxable: Boolean)(implicit hc: HeaderCarrier) :  Future[TaxEnrolmentSuscriberResponse] = {
     for {
       serviceName <- getServiceName
-      response <- getResponse(subscriptionId, serviceName)
+      response <- getResponse(subscriptionId, serviceName, taxable)
     } yield
     response
   }
@@ -69,5 +69,5 @@ class TaxEnrolmentConnectorImpl @Inject()(http: HttpClient,
 
 @ImplementedBy(classOf[TaxEnrolmentConnectorImpl])
 trait TaxEnrolmentConnector {
-  def enrolSubscriber(subscriptionId: String)(implicit hc: HeaderCarrier):  Future[TaxEnrolmentSuscriberResponse]
+  def enrolSubscriber(subscriptionId: String, taxable: Boolean)(implicit hc: HeaderCarrier):  Future[TaxEnrolmentSuscriberResponse]
 }

--- a/app/controllers/RegisterTrustController.scala
+++ b/app/controllers/RegisterTrustController.scala
@@ -84,7 +84,7 @@ class RegisterTrustController @Inject()(desService: DesService, config: AppConfi
 
                       rosmPatternService.enrolAndLogResult(response.trn,
                         request.affinityGroup,
-                        trustsRegistrationRequest.trust.details.trustTaxable.getOrElse(false)
+                        trustsRegistrationRequest.trust.details.trustTaxable.getOrElse(true)
                       ) map {
                         _ =>
                           Ok(Json.toJson(response))

--- a/app/controllers/RegisterTrustController.scala
+++ b/app/controllers/RegisterTrustController.scala
@@ -82,7 +82,10 @@ class RegisterTrustController @Inject()(desService: DesService, config: AppConfi
                         response = response
                       )
 
-                      rosmPatternService.enrolAndLogResult(response.trn, request.affinityGroup) map {
+                      rosmPatternService.enrolAndLogResult(response.trn,
+                        request.affinityGroup,
+                        trustsRegistrationRequest.trust.details.trustTaxable.getOrElse(false)
+                      ) map {
                         _ =>
                           Ok(Json.toJson(response))
                       }

--- a/app/controllers/TaxEnrolmentCallbackController.scala
+++ b/app/controllers/TaxEnrolmentCallbackController.scala
@@ -32,7 +32,7 @@ class TaxEnrolmentCallbackController @Inject()(
                                                 cc: ControllerComponents
                                                ) extends BackendController(cc) with Logging {
 
-  def subscriptionCallback() = Action.async(parse.json) {
+  def subscriptionCallback(trn: String) = Action.async(parse.json) {
     implicit request =>
       val hc : HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(request.headers)
 

--- a/app/controllers/TaxEnrolmentCallbackController.scala
+++ b/app/controllers/TaxEnrolmentCallbackController.scala
@@ -32,12 +32,21 @@ class TaxEnrolmentCallbackController @Inject()(
                                                 cc: ControllerComponents
                                                ) extends BackendController(cc) with Logging {
 
-  def subscriptionCallback(trn: String) = Action.async(parse.json) {
+  def taxableSubscriptionCallback(trn: String) = Action.async(parse.json) {
     implicit request =>
       val hc : HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(request.headers)
 
-      logger.info(s"[subscriptionCallback][Session ID: ${Session.id(hc)}]" +
-        s" Tax-Enrolment: subscription callback message was  : ${request.body}")
+      logger.info(s"[taxableSubscriptionCallback][Session ID: ${Session.id(hc)}]" +
+        s" Tax-Enrolment: taxable subscription callback message was  : ${request.body}")
+      Future(Ok(""))
+  }
+
+  def nonTaxableSubscriptionCallback(trn: String) = Action.async(parse.json) {
+    implicit request =>
+      val hc : HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(request.headers)
+
+      logger.info(s"[nonTaxableSubscriptionCallback][Session ID: ${Session.id(hc)}]" +
+        s" Tax-Enrolment: non-taxable subscription callback message was  : ${request.body}")
       Future(Ok(""))
   }
 

--- a/app/services/RosmPatternService.scala
+++ b/app/services/RosmPatternService.scala
@@ -35,7 +35,7 @@ class RosmPatternServiceImpl @Inject()( desService :DesService, taxEnrolmentServ
 
     for {
       subscriptionIdResponse <- desService.getSubscriptionId(trn = trn)
-      taxEnrolmentSuscriberResponse <- taxEnrolmentService.setSubscriptionId(subscriptionIdResponse.subscriptionId, taxable)
+      taxEnrolmentSuscriberResponse <- taxEnrolmentService.setSubscriptionId(subscriptionIdResponse.subscriptionId, taxable, trn)
     } yield {
       taxEnrolmentSuscriberResponse
     }

--- a/app/services/RosmPatternService.scala
+++ b/app/services/RosmPatternService.scala
@@ -31,21 +31,21 @@ import scala.util.control.NonFatal
 
 class RosmPatternServiceImpl @Inject()( desService :DesService, taxEnrolmentService : TaxEnrolmentsService) extends RosmPatternService with Logging {
 
-  override def setSubscriptionId(trn : String)(implicit hc : HeaderCarrier): Future[TaxEnrolmentSuscriberResponse] ={
+  override def setSubscriptionId(trn : String, taxable: Boolean)(implicit hc : HeaderCarrier): Future[TaxEnrolmentSuscriberResponse] ={
 
     for {
       subscriptionIdResponse <- desService.getSubscriptionId(trn = trn)
-      taxEnrolmentSuscriberResponse <- taxEnrolmentService.setSubscriptionId(subscriptionIdResponse.subscriptionId)
+      taxEnrolmentSuscriberResponse <- taxEnrolmentService.setSubscriptionId(subscriptionIdResponse.subscriptionId, taxable)
     } yield {
       taxEnrolmentSuscriberResponse
     }
   }
 
-  override def enrolAndLogResult(trn: String, affinityGroup: AffinityGroup)
+  override def enrolAndLogResult(trn: String, affinityGroup: AffinityGroup, taxable: Boolean)
                                                     (implicit hc: HeaderCarrier) : Future[TaxEnrolmentSuscriberResponse] = {
     affinityGroup match {
       case AffinityGroup.Organisation =>
-        setSubscriptionId(trn) map {
+        setSubscriptionId(trn, taxable) map {
           case TaxEnrolmentSuccess =>
             logger.info(s"[enrolAndLogResult][Session ID: ${Session.id(hc)}]" +
               s" Rosm completed successfully for provided trn : $trn.")
@@ -72,6 +72,6 @@ class RosmPatternServiceImpl @Inject()( desService :DesService, taxEnrolmentServ
 }
 @ImplementedBy(classOf[RosmPatternServiceImpl])
 trait RosmPatternService {
-  def setSubscriptionId(trn : String)(implicit hc : HeaderCarrier): Future[TaxEnrolmentSuscriberResponse]
-  def enrolAndLogResult(trn: String, affinityGroup: AffinityGroup)(implicit hc: HeaderCarrier) : Future[TaxEnrolmentSuscriberResponse]
+  def setSubscriptionId(trn : String, taxable: Boolean)(implicit hc : HeaderCarrier): Future[TaxEnrolmentSuscriberResponse]
+  def enrolAndLogResult(trn: String, affinityGroup: AffinityGroup, taxable: Boolean)(implicit hc: HeaderCarrier) : Future[TaxEnrolmentSuscriberResponse]
 }

--- a/app/services/TaxEnrolmentsService.scala
+++ b/app/services/TaxEnrolmentsService.scala
@@ -38,14 +38,14 @@ class TaxEnrolmentsServiceImpl @Inject()(taxEnrolmentConnector :TaxEnrolmentConn
   private val DELAY_SECONDS_BETWEEN_REQUEST = config.delayToConnectTaxEnrolment
   private val MAX_TRIES = config.maxRetry
 
-  override def setSubscriptionId(subscriptionId: String)(implicit hc: HeaderCarrier): Future[TaxEnrolmentSuscriberResponse] = {
+  override def setSubscriptionId(subscriptionId: String, taxable: Boolean)(implicit hc: HeaderCarrier): Future[TaxEnrolmentSuscriberResponse] = {
     implicit val as: ActorSystem = ActorSystem()
-    enrolSubscriberWithRetry(subscriptionId, 1)
+    enrolSubscriberWithRetry(subscriptionId, 1, taxable)
   }
 
-  private def enrolSubscriberWithRetry(subscriptionId: String, acc: Int)
+  private def enrolSubscriberWithRetry(subscriptionId: String, acc: Int, taxable: Boolean)
                                       (implicit as: ActorSystem, hc: HeaderCarrier): Future[TaxEnrolmentSuscriberResponse] = {
-    makeRequest(subscriptionId) recoverWith {
+    makeRequest(subscriptionId, taxable) recoverWith {
       case NonFatal(_) =>
         if (isMaxRetryReached(acc)) {
           logger.error(s"[enrolSubscriberWithRetry][Session ID: ${Session.id(hc)}]" +
@@ -55,7 +55,7 @@ class TaxEnrolmentsServiceImpl @Inject()(taxEnrolmentConnector :TaxEnrolmentConn
           after(DELAY_SECONDS_BETWEEN_REQUEST.seconds, as.scheduler){
             logger.error(s"[enrolSubscriberWithRetry][Session ID: ${Session.id(hc)}]" +
               s" Retrying to enrol subscription id $subscriptionId,  $acc")
-            enrolSubscriberWithRetry(subscriptionId, acc + 1)
+            enrolSubscriberWithRetry(subscriptionId, acc + 1, taxable)
           }
       }
     }
@@ -64,13 +64,13 @@ class TaxEnrolmentsServiceImpl @Inject()(taxEnrolmentConnector :TaxEnrolmentConn
   private def isMaxRetryReached(currentCounter: Int): Boolean =
     currentCounter == MAX_TRIES
 
-  private def makeRequest(subscriptionId: String)(implicit hc: HeaderCarrier): Future[TaxEnrolmentSuscriberResponse] = {
-    taxEnrolmentConnector.enrolSubscriber(subscriptionId)
+  private def makeRequest(subscriptionId: String, taxable: Boolean)(implicit hc: HeaderCarrier): Future[TaxEnrolmentSuscriberResponse] = {
+    taxEnrolmentConnector.enrolSubscriber(subscriptionId, taxable)
   }
 
 }
 
 @ImplementedBy(classOf[TaxEnrolmentsServiceImpl])
 trait TaxEnrolmentsService{
-   def setSubscriptionId(subscriptionId: String)(implicit hc: HeaderCarrier): Future[TaxEnrolmentSuscriberResponse]
+   def setSubscriptionId(subscriptionId: String, taxable: Boolean)(implicit hc: HeaderCarrier): Future[TaxEnrolmentSuscriberResponse]
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -202,14 +202,17 @@ microservice {
         }
 
         tax-enrolments {
+            protocol = http
             host=localhost
             port=9802
             non-taxable {
-                serviceName="serviceName"
+                serviceName="serviceNameNonTaxable"
                 callback="http://localhost:9782/trusts/tax-enrolment/registration/non-taxable/hmrc-tersnt-org/:trn/subscriptions"
             }
-            serviceName="serviceName"
-            callback="http://localhost:9782/trusts/tax-enrolment/registration/taxable/hmrc-ters-org/:trn/subscriptions"
+            taxable {
+                serviceName="serviceNameTaxable"
+                callback="http://localhost:9782/trusts/tax-enrolment/registration/non-taxable/hmrc-tersnt-org/:trn/subscriptions"
+            }
         }
     }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -208,7 +208,7 @@ microservice {
             }
             taxable {
                 serviceName="serviceNameTaxable"
-                callback="http://localhost:9782/trusts/tax-enrolment/registration/non-taxable/hmrc-tersnt-org/:trn/subscriptions"
+                callback="http://localhost:9782/trusts/tax-enrolment/registration/taxable/hmrc-ters-org/:trn/subscriptions"
             }
         }
     }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -204,9 +204,12 @@ microservice {
         tax-enrolments {
             host=localhost
             port=9802
-            serviceName5MLD="serviceName"
+            non-taxable {
+                serviceName="serviceName"
+                callback="http://localhost:9782/trusts/tax-enrolment/registration/non-taxable/hmrc-tersnt-org/:trn/subscriptions"
+            }
             serviceName="serviceName"
-            callback="http://localhost:9782/trusts/tax-enrolment/callback/subscriptions"
+            callback="http://localhost:9782/trusts/tax-enrolment/registration/taxable/hmrc-ters-org/:trn/subscriptions"
         }
     }
 }

--- a/conf/trusts.routes
+++ b/conf/trusts.routes
@@ -9,8 +9,8 @@
 
 POST        /check                                                     controllers.CheckTrustController.checkExistingTrust
 
-POST        /tax-enrolment/registration/taxable/hmrc-ters-org/:trn/subscriptions            controllers.TaxEnrolmentCallbackController.subscriptionCallback(trn: String)
-POST        /tax-enrolment/registration/non-taxable/hmrc-tersnt-org/:trn/subscriptions      controllers.TaxEnrolmentCallbackController.subscriptionCallback(trn: String)
+POST        /tax-enrolment/registration/taxable/hmrc-ters-org/:trn/subscriptions            controllers.TaxEnrolmentCallbackController.taxableSubscriptionCallback(trn: String)
+POST        /tax-enrolment/registration/non-taxable/hmrc-tersnt-org/:trn/subscriptions      controllers.TaxEnrolmentCallbackController.nonTaxableSubscriptionCallback(trn: String)
 
 GET         /:identifier/refresh                                       controllers.GetTrustController.getFromEtmp(identifier: String)
 

--- a/conf/trusts.routes
+++ b/conf/trusts.routes
@@ -9,7 +9,8 @@
 
 POST        /check                                                     controllers.CheckTrustController.checkExistingTrust
 
-POST        /tax-enrolment/callback/subscriptions                      controllers.TaxEnrolmentCallbackController.subscriptionCallback
+POST        /tax-enrolment/registration/taxable/hmrc-ters-org/:trn/subscriptions            controllers.TaxEnrolmentCallbackController.subscriptionCallback(trn: String)
+POST        /tax-enrolment/registration/non-taxable/hmrc-tersnt-org/:trn/subscriptions      controllers.TaxEnrolmentCallbackController.subscriptionCallback(trn: String)
 
 GET         /:identifier/refresh                                       controllers.GetTrustController.getFromEtmp(identifier: String)
 

--- a/test/connectors/ConnectorSpecHelper.scala
+++ b/test/connectors/ConnectorSpecHelper.scala
@@ -36,7 +36,15 @@ class ConnectorSpecHelper extends BaseSpec with WireMockHelper with IntegrationP
           "microservice.services.des-display-trust-or-estate.port" -> server.port(),
           "microservice.services.des-vary-trust-or-estate.port" -> server.port(),
           "microservice.services.tax-enrolments.port" -> server.port(),
-          "microservice.services.trusts-store.port" -> server.port()
+          "microservice.services.trusts-store.port" -> server.port(),
+
+          "microservice.services.tax-enrolments.non-taxable.serviceName" -> "serviceNameNonTaxable",
+          "microservice.services.tax-enrolments.non-taxable.callback" ->
+            "http://localhost:9782/trusts/tax-enrolment/registration/non-taxable/hmrc-tersnt-org/:trn/subscriptions",
+
+          "microservice.services.tax-enrolments.taxable.serviceName" -> "serviceNameTaxable",
+          "microservice.services.tax-enrolments.taxable.callback" ->
+            "http://localhost:9782/trusts/tax-enrolment/registration/taxable/hmrc-ters-org/:trn/subscriptions",
         ): _*)
   }
 

--- a/test/connectors/TaxEnrolmentConnectorSpec.scala
+++ b/test/connectors/TaxEnrolmentConnectorSpec.scala
@@ -40,7 +40,9 @@ class TaxEnrolmentConnectorSpec extends ConnectorSpecHelper {
       )
   }
 
-  ".enrolSubscriber" should {
+  ".enrolSubscriber 4MLD" should {
+
+    val taxable: Boolean = false
 
     "return Success " when {
       "tax enrolments succesfully subscribed to provided subscription id" in {
@@ -49,7 +51,7 @@ class TaxEnrolmentConnectorSpec extends ConnectorSpecHelper {
 
         stubForPut(server, "/tax-enrolments/subscriptions/123456789/subscriber", 204)
 
-        val futureResult = connector.enrolSubscriber("123456789")
+        val futureResult = connector.enrolSubscriber("123456789", taxable)
 
         whenReady(futureResult) {
           result => result mustBe TaxEnrolmentSuccess
@@ -64,7 +66,7 @@ class TaxEnrolmentConnectorSpec extends ConnectorSpecHelper {
 
         stubForPut(server, "/tax-enrolments/subscriptions/987654321/subscriber", 400)
 
-        val futureResult = connector.enrolSubscriber("987654321")
+        val futureResult = connector.enrolSubscriber("987654321", taxable)
 
         whenReady(futureResult.failed) {
           result => result mustBe BadRequestException
@@ -79,7 +81,7 @@ class TaxEnrolmentConnectorSpec extends ConnectorSpecHelper {
 
         stubForPut(server, "/tax-enrolments/subscriptions/987654321/subscriber", 500)
 
-        val futureResult = connector.enrolSubscriber("987654321")
+        val futureResult = connector.enrolSubscriber("987654321", taxable)
 
         whenReady(futureResult.failed) {
           result => result mustBe an[InternalServerErrorException]

--- a/test/connectors/TaxEnrolmentConnectorSpec.scala
+++ b/test/connectors/TaxEnrolmentConnectorSpec.scala
@@ -43,6 +43,7 @@ class TaxEnrolmentConnectorSpec extends ConnectorSpecHelper {
   ".enrolSubscriber 4MLD" should {
 
     val taxable: Boolean = false
+    val trn = "XTRN1234567"
 
     "return Success " when {
       "tax enrolments succesfully subscribed to provided subscription id" in {
@@ -51,7 +52,7 @@ class TaxEnrolmentConnectorSpec extends ConnectorSpecHelper {
 
         stubForPut(server, "/tax-enrolments/subscriptions/123456789/subscriber", 204)
 
-        val futureResult = connector.enrolSubscriber("123456789", taxable)
+        val futureResult = connector.enrolSubscriber("123456789", taxable, trn)
 
         whenReady(futureResult) {
           result => result mustBe TaxEnrolmentSuccess
@@ -66,7 +67,7 @@ class TaxEnrolmentConnectorSpec extends ConnectorSpecHelper {
 
         stubForPut(server, "/tax-enrolments/subscriptions/987654321/subscriber", 400)
 
-        val futureResult = connector.enrolSubscriber("987654321", taxable)
+        val futureResult = connector.enrolSubscriber("987654321", taxable, trn)
 
         whenReady(futureResult.failed) {
           result => result mustBe BadRequestException
@@ -81,7 +82,7 @@ class TaxEnrolmentConnectorSpec extends ConnectorSpecHelper {
 
         stubForPut(server, "/tax-enrolments/subscriptions/987654321/subscriber", 500)
 
-        val futureResult = connector.enrolSubscriber("987654321", taxable)
+        val futureResult = connector.enrolSubscriber("987654321", taxable, trn)
 
         whenReady(futureResult.failed) {
           result => result mustBe an[InternalServerErrorException]

--- a/test/connectors/TaxEnrolmentConnectorSpec.scala
+++ b/test/connectors/TaxEnrolmentConnectorSpec.scala
@@ -16,9 +16,10 @@
 
 package connectors
 
+import config.AppConfig
 import connector.TaxEnrolmentConnector
 import exceptions.{BadRequestException, InternalServerErrorException}
-import models.tax_enrolments.TaxEnrolmentSuccess
+import models.tax_enrolments.{TaxEnrolmentSubscription, TaxEnrolmentSuccess, TaxEnrolmentSuscriberResponse}
 import org.mockito.Matchers.any
 import org.mockito.Mockito.when
 import play.api.inject.bind
@@ -31,18 +32,21 @@ import scala.concurrent.{ExecutionContext, Future}
 class TaxEnrolmentConnectorSpec extends ConnectorSpecHelper {
 
   lazy val connector: TaxEnrolmentConnector = injector.instanceOf[TaxEnrolmentConnector]
+
   private val mockTrustsStoreService = mock[TrustsStoreService]
+  private val mockConfig = mock[AppConfig]
 
   override def applicationBuilder(): GuiceApplicationBuilder = {
     super.applicationBuilder()
       .overrides(
+//        bind[AppConfig].toInstance(mockConfig),
         bind[TrustsStoreService].toInstance(mockTrustsStoreService)
       )
   }
 
   ".enrolSubscriber 4MLD" should {
 
-    val taxable: Boolean = false
+    val taxable: Boolean = true
     val trn = "XTRN1234567"
 
     "return Success " when {
@@ -79,6 +83,68 @@ class TaxEnrolmentConnectorSpec extends ConnectorSpecHelper {
       "tax enrolments returns internal server error " in {
 
         when(mockTrustsStoreService.is5mldEnabled()(any[HeaderCarrier], any[ExecutionContext])).thenReturn(Future.successful(false))
+
+        stubForPut(server, "/tax-enrolments/subscriptions/987654321/subscriber", 500)
+
+        val futureResult = connector.enrolSubscriber("987654321", taxable, trn)
+
+        whenReady(futureResult.failed) {
+          result => result mustBe an[InternalServerErrorException]
+        }
+      }
+    }
+  }
+
+  ".enrolSubscriber 5MLD" should {
+
+    val taxable: Boolean = false
+    val trn = "XTRN1234567"
+
+
+    "return correct TaxEnrolmentSubscription" when {
+      "calling getTaxEnrolmentSubscription" in {
+        when(mockTrustsStoreService.is5mldEnabled()(any[HeaderCarrier], any[ExecutionContext])).thenReturn(Future.successful(true))
+        when(mockConfig.taxEnrolmentsPayloadBodyCallbackNonTaxable(trn)).thenReturn("/foo")
+        when(mockConfig.taxEnrolmentsPayloadBodyServiceNameNonTaxable).thenReturn("serviceNameNonTaxable")
+        val result = connector.getTaxEnrolmentSubscription("123456789", true, false, trn)
+        result mustBe TaxEnrolmentSubscription("serviceNameNonTaxable", "/foo", "123456789")
+      }
+    }
+
+    "return Success " when {
+      "tax enrolments successfully subscribed to provided subscription id" in {
+
+        when(mockTrustsStoreService.is5mldEnabled()(any[HeaderCarrier], any[ExecutionContext])).thenReturn(Future.successful(true))
+
+        stubForPut(server, "/tax-enrolments/subscriptions/123456789/subscriber", 204)
+
+        val futureResult = connector.enrolSubscriber("123456789", taxable, trn)
+
+        whenReady(futureResult) {
+          result => result mustBe TaxEnrolmentSuccess
+        }
+      }
+    }
+
+    "return BadRequestException " when {
+      "tax enrolments returns bad request " in {
+
+        when(mockTrustsStoreService.is5mldEnabled()(any[HeaderCarrier], any[ExecutionContext])).thenReturn(Future.successful(true))
+
+        stubForPut(server, "/tax-enrolments/subscriptions/987654321/subscriber", 400)
+
+        val futureResult = connector.enrolSubscriber("987654321", taxable, trn)
+
+        whenReady(futureResult.failed) {
+          result => result mustBe BadRequestException
+        }
+      }
+    }
+
+    "return InternalServerErrorException " when {
+      "tax enrolments returns internal server error " in {
+
+        when(mockTrustsStoreService.is5mldEnabled()(any[HeaderCarrier], any[ExecutionContext])).thenReturn(Future.successful(true))
 
         stubForPut(server, "/tax-enrolments/subscriptions/987654321/subscriber", 500)
 

--- a/test/controllers/RegisterTrustControllerSpec.scala
+++ b/test/controllers/RegisterTrustControllerSpec.scala
@@ -65,7 +65,7 @@ class RegisterTrustControllerSpec extends BaseSpec {
         when(mockDesService.registerTrust(any[Registration]))
           .thenReturn(Future.successful(RegistrationTrnResponse(trnResponse)))
 
-        when(rosmPatternService.enrolAndLogResult(any(), any())(any())).thenReturn(Future.successful(TaxEnrolmentSuccess))
+        when(rosmPatternService.enrolAndLogResult(any(), any(), any())(any())).thenReturn(Future.successful(TaxEnrolmentSuccess))
 
         val SUT = new RegisterTrustController(
           mockDesService,
@@ -82,7 +82,7 @@ class RegisterTrustControllerSpec extends BaseSpec {
         status(result) mustBe OK
         (contentAsJson(result) \ "trn").as[String] mustBe trnResponse
 
-        verify(rosmPatternService, times(1)).enrolAndLogResult(any(), any())(any[HeaderCarrier])
+        verify(rosmPatternService, times(1)).enrolAndLogResult(any(), any(), any())(any[HeaderCarrier])
       }
 
       "individual user called the register endpoint with a valid 5mld json payload " in {
@@ -92,7 +92,7 @@ class RegisterTrustControllerSpec extends BaseSpec {
         when(mockDesService.registerTrust(any[Registration]))
           .thenReturn(Future.successful(RegistrationTrnResponse(trnResponse)))
 
-        when(rosmPatternService.enrolAndLogResult(any(), any())(any())).thenReturn(Future.successful(TaxEnrolmentSuccess))
+        when(rosmPatternService.enrolAndLogResult(any(), any(), any())(any())).thenReturn(Future.successful(TaxEnrolmentSuccess))
 
         val SUT = new RegisterTrustController(
           mockDesService,
@@ -109,7 +109,7 @@ class RegisterTrustControllerSpec extends BaseSpec {
         status(result) mustBe OK
         (contentAsJson(result) \ "trn").as[String] mustBe trnResponse
 
-        verify(rosmPatternService, times(1)).enrolAndLogResult(any(), any())(any[HeaderCarrier])
+        verify(rosmPatternService, times(1)).enrolAndLogResult(any(), any(), any())(any[HeaderCarrier])
       }
 
       "individual user called the register endpoint with a valid 5mld nontaxable json payload " in {
@@ -119,7 +119,7 @@ class RegisterTrustControllerSpec extends BaseSpec {
         when(mockDesService.registerTrust(any[Registration]))
           .thenReturn(Future.successful(RegistrationTrnResponse(trnResponse)))
 
-        when(rosmPatternService.enrolAndLogResult(any(), any())(any())).thenReturn(Future.successful(TaxEnrolmentSuccess))
+        when(rosmPatternService.enrolAndLogResult(any(), any(), any())(any())).thenReturn(Future.successful(TaxEnrolmentSuccess))
 
         val SUT = new RegisterTrustController(
           mockDesService,
@@ -136,7 +136,7 @@ class RegisterTrustControllerSpec extends BaseSpec {
         status(result) mustBe OK
         (contentAsJson(result) \ "trn").as[String] mustBe trnResponse
 
-        verify(rosmPatternService, times(1)).enrolAndLogResult(any(), any())(any[HeaderCarrier])
+        verify(rosmPatternService, times(1)).enrolAndLogResult(any(), any(), any())(any[HeaderCarrier])
       }
 
       "individual user called the register endpoint with a valid json payload " when {
@@ -146,7 +146,7 @@ class RegisterTrustControllerSpec extends BaseSpec {
           when(mockDesService.registerTrust(any[Registration]))
             .thenReturn(Future.successful(RegistrationTrnResponse(trnResponse)))
 
-          when(rosmPatternService.enrolAndLogResult(any(), any())(any())).thenReturn(Future.successful(TaxEnrolmentFailure))
+          when(rosmPatternService.enrolAndLogResult(any(), any(), any())(any())).thenReturn(Future.successful(TaxEnrolmentFailure))
 
           val SUT = new RegisterTrustController(
             mockDesService,
@@ -163,13 +163,13 @@ class RegisterTrustControllerSpec extends BaseSpec {
           status(result) mustBe OK
           (contentAsJson(result) \ "trn").as[String] mustBe trnResponse
 
-          verify(rosmPatternService, times(1)).enrolAndLogResult(any(), any())(any[HeaderCarrier])
+          verify(rosmPatternService, times(1)).enrolAndLogResult(any(), any(), any())(any[HeaderCarrier])
         }
       }
 
       "agent user submits trusts payload" in {
 
-        when(rosmPatternService.enrolAndLogResult(any(), any())(any())).thenReturn(Future.successful(TaxEnrolmentNotProcessed))
+        when(rosmPatternService.enrolAndLogResult(any(), any(), any())(any())).thenReturn(Future.successful(TaxEnrolmentNotProcessed))
 
         val SUT = new RegisterTrustController(
           mockDesService,
@@ -188,7 +188,7 @@ class RegisterTrustControllerSpec extends BaseSpec {
 
         (contentAsJson(result) \ "trn").as[String] mustBe trnResponse
 
-        verify(rosmPatternService, times(1)).enrolAndLogResult(any(), any())(any[HeaderCarrier])
+        verify(rosmPatternService, times(1)).enrolAndLogResult(any(), any(), any())(any[HeaderCarrier])
       }
     }
 
@@ -217,7 +217,7 @@ class RegisterTrustControllerSpec extends BaseSpec {
         (output \ "code").as[String] mustBe "ALREADY_REGISTERED"
         (output \ "message").as[String] mustBe "The trust is already registered."
 
-        verify(rosmPatternService, times(0)).enrolAndLogResult(any(), any())(any[HeaderCarrier])
+        verify(rosmPatternService, times(0)).enrolAndLogResult(any(), any(), any())(any[HeaderCarrier])
       }
     }
 
@@ -243,7 +243,7 @@ class RegisterTrustControllerSpec extends BaseSpec {
         val output = contentAsJson(result)
         (output \ "code").as[String] mustBe "NO_MATCH"
         (output \ "message").as[String] mustBe "No match has been found in HMRC's records."
-        verify(rosmPatternService, times(0)).enrolAndLogResult(any(), any())(any[HeaderCarrier])
+        verify(rosmPatternService, times(0)).enrolAndLogResult(any(), any(), any())(any[HeaderCarrier])
       }
     }
 
@@ -270,7 +270,7 @@ class RegisterTrustControllerSpec extends BaseSpec {
         (output \ "code").as[String] mustBe "BAD_REQUEST"
         (output \ "message").as[String] mustBe "Provided request is invalid."
 
-        verify(rosmPatternService, times(0)).enrolAndLogResult(any(), any())(any[HeaderCarrier])
+        verify(rosmPatternService, times(0)).enrolAndLogResult(any(), any(), any())(any[HeaderCarrier])
       }
 
       "input request fails business validation" in {
@@ -291,7 +291,7 @@ class RegisterTrustControllerSpec extends BaseSpec {
         val output = contentAsJson(result)
         (output \ "code").as[String] mustBe "BAD_REQUEST"
         (output \ "message").as[String] mustBe "Provided request is invalid."
-        verify(rosmPatternService, times(0)).enrolAndLogResult(any(), any())(any[HeaderCarrier])
+        verify(rosmPatternService, times(0)).enrolAndLogResult(any(), any(), any())(any[HeaderCarrier])
       }
 
       "no draft id is provided in the headers" in {
@@ -319,7 +319,7 @@ class RegisterTrustControllerSpec extends BaseSpec {
         (output \ "code").as[String] mustBe "NO_DRAFT_ID"
         (output \ "message").as[String] mustBe "No draft registration identifier provided."
 
-        verify(rosmPatternService, times(0)).enrolAndLogResult(any(), any())(any[HeaderCarrier])
+        verify(rosmPatternService, times(0)).enrolAndLogResult(any(), any(), any())(any[HeaderCarrier])
       }
 
     }
@@ -348,7 +348,7 @@ class RegisterTrustControllerSpec extends BaseSpec {
         val output = contentAsJson(result)
         (output \ "code").as[String] mustBe "INTERNAL_SERVER_ERROR"
         (output \ "message").as[String] mustBe "Internal server error."
-        verify(rosmPatternService, times(0)).enrolAndLogResult(any(), any())(any[HeaderCarrier])
+        verify(rosmPatternService, times(0)).enrolAndLogResult(any(), any(), any())(any[HeaderCarrier])
       }
     }
 
@@ -376,7 +376,7 @@ class RegisterTrustControllerSpec extends BaseSpec {
         val output = contentAsJson(result)
         (output \ "code").as[String] mustBe "INTERNAL_SERVER_ERROR"
         (output \ "message").as[String] mustBe "Internal server error."
-        verify(rosmPatternService, times(0)).enrolAndLogResult(any(), any())(any[HeaderCarrier])
+        verify(rosmPatternService, times(0)).enrolAndLogResult(any(), any(), any())(any[HeaderCarrier])
       }
     }
 
@@ -404,7 +404,7 @@ class RegisterTrustControllerSpec extends BaseSpec {
         val output = contentAsJson(result)
         (output \ "code").as[String] mustBe "INTERNAL_SERVER_ERROR"
         (output \ "message").as[String] mustBe "Internal server error."
-        verify(rosmPatternService, times(0)).enrolAndLogResult(any(), any())(any[HeaderCarrier])
+        verify(rosmPatternService, times(0)).enrolAndLogResult(any(), any(), any())(any[HeaderCarrier])
       }
     }
   }

--- a/test/controllers/TaxEnrolmentCallbackControllerSpec.scala
+++ b/test/controllers/TaxEnrolmentCallbackControllerSpec.scala
@@ -26,6 +26,7 @@ import play.api.test.Helpers.{status, _}
 class TaxEnrolmentCallbackControllerSpec extends BaseSpec with GuiceOneServerPerSuite {
 
   val auditConnector = mock[AuditConnector]
+  val trn = "XTRN1234567"
 
   ".subscriptionCallback" should {
 
@@ -33,7 +34,7 @@ class TaxEnrolmentCallbackControllerSpec extends BaseSpec with GuiceOneServerPer
       "tax enrolment callback for subscription id enrolment  " in {
         val SUT = new TaxEnrolmentCallbackController(Helpers.stubControllerComponents())
 
-        val result = SUT.subscriptionCallback().apply(postRequestWithPayload(Json.parse({"""{ "url" : "http//","state" : "SUCCESS"}"""})))
+        val result = SUT.subscriptionCallback(trn).apply(postRequestWithPayload(Json.parse({"""{ "url" : "http//","state" : "SUCCESS"}"""})))
         status(result) mustBe OK
       }
     }

--- a/test/controllers/TaxEnrolmentCallbackControllerSpec.scala
+++ b/test/controllers/TaxEnrolmentCallbackControllerSpec.scala
@@ -28,13 +28,25 @@ class TaxEnrolmentCallbackControllerSpec extends BaseSpec with GuiceOneServerPer
   val auditConnector = mock[AuditConnector]
   val trn = "XTRN1234567"
 
-  ".subscriptionCallback" should {
+  ".taxableSubscriptionCallback" should {
 
     "return 200 " when {
       "tax enrolment callback for subscription id enrolment  " in {
         val SUT = new TaxEnrolmentCallbackController(Helpers.stubControllerComponents())
 
-        val result = SUT.subscriptionCallback(trn).apply(postRequestWithPayload(Json.parse({"""{ "url" : "http//","state" : "SUCCESS"}"""})))
+        val result = SUT.taxableSubscriptionCallback(trn).apply(postRequestWithPayload(Json.parse({"""{ "url" : "http//","state" : "SUCCESS"}"""})))
+        status(result) mustBe OK
+      }
+    }
+  }
+
+  ".nonTaxableSubscriptionCallback" should {
+
+    "return 200 " when {
+      "tax enrolment callback for subscription id enrolment  " in {
+        val SUT = new TaxEnrolmentCallbackController(Helpers.stubControllerComponents())
+
+        val result = SUT.nonTaxableSubscriptionCallback(trn).apply(postRequestWithPayload(Json.parse({"""{ "url" : "http//","state" : "SUCCESS"}"""})))
         status(result) mustBe OK
       }
     }

--- a/test/services/RosmPatternServiceSpec.scala
+++ b/test/services/RosmPatternServiceSpec.scala
@@ -32,7 +32,7 @@ class RosmPatternServiceSpec extends BaseSpec {
 
   private val SUT = new RosmPatternServiceImpl(mockDesService, mockTaxEnrolmentsService)
 
-  ".completeRosmTransaction 4MLD" should {
+  ".completeRosmTransaction" should {
 
     val taxable: Boolean = false
     val trn = "XTRN1234567"

--- a/test/services/RosmPatternServiceSpec.scala
+++ b/test/services/RosmPatternServiceSpec.scala
@@ -32,16 +32,18 @@ class RosmPatternServiceSpec extends BaseSpec {
 
   private val SUT = new RosmPatternServiceImpl(mockDesService, mockTaxEnrolmentsService)
 
-  ".completeRosmTransaction" should {
+  ".completeRosmTransaction 4MLD" should {
+
+    val taxable: Boolean = false
 
     "return success taxEnrolmentSuscriberResponse " when {
       "successfully sets subscriptionId id in tax enrolments for provided trn." in {
         when(mockDesService.getSubscriptionId("trn123456789")).
           thenReturn(Future.successful(SubscriptionIdResponse("123456789")))
-        when(mockTaxEnrolmentsService.setSubscriptionId("123456789")).
+        when(mockTaxEnrolmentsService.setSubscriptionId("123456789", taxable)).
           thenReturn(Future.successful(TaxEnrolmentSuccess))
 
-        val futureResult = SUT.setSubscriptionId("trn123456789")
+        val futureResult = SUT.setSubscriptionId("trn123456789", taxable)
 
         whenReady(futureResult) {
           result => result mustBe TaxEnrolmentSuccess
@@ -53,10 +55,10 @@ class RosmPatternServiceSpec extends BaseSpec {
       "des is down and not able to return subscription id." in {
         when(mockDesService.getSubscriptionId("trn123456789")).
           thenReturn(Future.failed(InternalServerErrorException("")))
-        when(mockTaxEnrolmentsService.setSubscriptionId("123456789")).
+        when(mockTaxEnrolmentsService.setSubscriptionId("123456789", taxable)).
           thenReturn(Future.successful(TaxEnrolmentSuccess))
 
-        val futureResult = SUT.setSubscriptionId("trn123456789")
+        val futureResult = SUT.setSubscriptionId("trn123456789", taxable)
 
         whenReady(futureResult.failed) {
           result => result mustBe an[InternalServerErrorException]
@@ -68,10 +70,10 @@ class RosmPatternServiceSpec extends BaseSpec {
       "tax enrolment service is down " in {
         when(mockDesService.getSubscriptionId("trn123456789")).
           thenReturn(Future.successful(SubscriptionIdResponse("123456789")))
-        when(mockTaxEnrolmentsService.setSubscriptionId("123456789")).
+        when(mockTaxEnrolmentsService.setSubscriptionId("123456789", taxable)).
           thenReturn(Future.successful(TaxEnrolmentFailure))
 
-        val futureResult = SUT.setSubscriptionId("trn123456789")
+        val futureResult = SUT.setSubscriptionId("trn123456789", taxable)
 
         whenReady(futureResult) {
           result => result mustBe TaxEnrolmentFailure
@@ -82,10 +84,10 @@ class RosmPatternServiceSpec extends BaseSpec {
       "tax enrolment service does not found provided subscription id." in {
         when(mockDesService.getSubscriptionId("trn123456789")).
           thenReturn(Future.successful(SubscriptionIdResponse("123456789")))
-        when(mockTaxEnrolmentsService.setSubscriptionId("123456789")).
+        when(mockTaxEnrolmentsService.setSubscriptionId("123456789", taxable)).
           thenReturn(Future.failed(BadRequestException))
 
-        val futureResult = SUT.setSubscriptionId("trn123456789")
+        val futureResult = SUT.setSubscriptionId("trn123456789", taxable)
 
         whenReady(futureResult.failed) {
           result => result mustBe BadRequestException

--- a/test/services/RosmPatternServiceSpec.scala
+++ b/test/services/RosmPatternServiceSpec.scala
@@ -35,15 +35,16 @@ class RosmPatternServiceSpec extends BaseSpec {
   ".completeRosmTransaction 4MLD" should {
 
     val taxable: Boolean = false
+    val trn = "XTRN1234567"
 
     "return success taxEnrolmentSuscriberResponse " when {
       "successfully sets subscriptionId id in tax enrolments for provided trn." in {
-        when(mockDesService.getSubscriptionId("trn123456789")).
+        when(mockDesService.getSubscriptionId(trn)).
           thenReturn(Future.successful(SubscriptionIdResponse("123456789")))
-        when(mockTaxEnrolmentsService.setSubscriptionId("123456789", taxable)).
+        when(mockTaxEnrolmentsService.setSubscriptionId("123456789", taxable, trn)).
           thenReturn(Future.successful(TaxEnrolmentSuccess))
 
-        val futureResult = SUT.setSubscriptionId("trn123456789", taxable)
+        val futureResult = SUT.setSubscriptionId(trn, taxable)
 
         whenReady(futureResult) {
           result => result mustBe TaxEnrolmentSuccess
@@ -53,12 +54,12 @@ class RosmPatternServiceSpec extends BaseSpec {
 
     "return InternalServerErrorException " when {
       "des is down and not able to return subscription id." in {
-        when(mockDesService.getSubscriptionId("trn123456789")).
+        when(mockDesService.getSubscriptionId(trn)).
           thenReturn(Future.failed(InternalServerErrorException("")))
-        when(mockTaxEnrolmentsService.setSubscriptionId("123456789", taxable)).
+        when(mockTaxEnrolmentsService.setSubscriptionId("123456789", taxable, trn)).
           thenReturn(Future.successful(TaxEnrolmentSuccess))
 
-        val futureResult = SUT.setSubscriptionId("trn123456789", taxable)
+        val futureResult = SUT.setSubscriptionId(trn, taxable)
 
         whenReady(futureResult.failed) {
           result => result mustBe an[InternalServerErrorException]
@@ -68,12 +69,12 @@ class RosmPatternServiceSpec extends BaseSpec {
 
     "return InternalServerErrorException " when {
       "tax enrolment service is down " in {
-        when(mockDesService.getSubscriptionId("trn123456789")).
+        when(mockDesService.getSubscriptionId(trn)).
           thenReturn(Future.successful(SubscriptionIdResponse("123456789")))
-        when(mockTaxEnrolmentsService.setSubscriptionId("123456789", taxable)).
+        when(mockTaxEnrolmentsService.setSubscriptionId("123456789", taxable, trn)).
           thenReturn(Future.successful(TaxEnrolmentFailure))
 
-        val futureResult = SUT.setSubscriptionId("trn123456789", taxable)
+        val futureResult = SUT.setSubscriptionId(trn, taxable)
 
         whenReady(futureResult) {
           result => result mustBe TaxEnrolmentFailure
@@ -82,12 +83,12 @@ class RosmPatternServiceSpec extends BaseSpec {
     }
     "return BadRequestException " when {
       "tax enrolment service does not found provided subscription id." in {
-        when(mockDesService.getSubscriptionId("trn123456789")).
+        when(mockDesService.getSubscriptionId(trn)).
           thenReturn(Future.successful(SubscriptionIdResponse("123456789")))
-        when(mockTaxEnrolmentsService.setSubscriptionId("123456789", taxable)).
+        when(mockTaxEnrolmentsService.setSubscriptionId("123456789", taxable, trn)).
           thenReturn(Future.failed(BadRequestException))
 
-        val futureResult = SUT.setSubscriptionId("trn123456789", taxable)
+        val futureResult = SUT.setSubscriptionId(trn, taxable)
 
         whenReady(futureResult.failed) {
           result => result mustBe BadRequestException

--- a/test/services/TaxEnrolmentsServiceSpec.scala
+++ b/test/services/TaxEnrolmentsServiceSpec.scala
@@ -41,39 +41,40 @@ class TaxEnrolmentsServiceSpec extends BaseSpec {
   ".setSubscriptionId 4MLD" should {
 
     val taxable: Boolean = false
+    val trn = "XTRN1234567"
 
     "return TaxEnrolmentSuccess  " when {
       "connector returns success taxEnrolmentSuscriberResponse." in {
-        when(mockConnector.enrolSubscriber("123456789", taxable)).
+        when(mockConnector.enrolSubscriber("123456789", taxable, trn)).
           thenReturn(Future.successful(TaxEnrolmentSuccess))
 
-        val futureResult = SUT.setSubscriptionId("123456789", taxable)
+        val futureResult = SUT.setSubscriptionId("123456789", taxable, trn)
 
         whenReady(futureResult) {
           result => result mustBe TaxEnrolmentSuccess
         }
-        verify(mockConnector, times(1)).enrolSubscriber(any(), any())(any[HeaderCarrier])
+        verify(mockConnector, times(1)).enrolSubscriber(any(), any(), any())(any[HeaderCarrier])
       }
     }
 
     "return TaxEnrolmentFailure " when {
       "tax enrolment returns internal server error." in {
-        when(mockConnector.enrolSubscriber("123456789", taxable)).
+        when(mockConnector.enrolSubscriber("123456789", taxable, trn)).
           thenReturn(Future.failed(new InternalServerErrorException("")))
-        val result = Await.result(SUT.setSubscriptionId("123456789", taxable), Duration.Inf)
+        val result = Await.result(SUT.setSubscriptionId("123456789", taxable, trn), Duration.Inf)
         result mustBe TaxEnrolmentFailure
-        verify(mockConnector, times(10)).enrolSubscriber(any(), any())(any[HeaderCarrier])
+        verify(mockConnector, times(10)).enrolSubscriber(any(), any(), any())(any[HeaderCarrier])
       }
     }
 
     "return TaxEnrolmentFailure " when {
       "tax enrolment returns error" in {
-        when(mockConnector.enrolSubscriber("123456789", taxable)).
+        when(mockConnector.enrolSubscriber("123456789", taxable, trn)).
           thenReturn(Future.failed(BadRequestException))
 
-        val result = Await.result(SUT.setSubscriptionId("123456789", taxable), Duration.Inf)
+        val result = Await.result(SUT.setSubscriptionId("123456789", taxable, trn), Duration.Inf)
         result mustBe TaxEnrolmentFailure
-        verify(mockConnector, times(10)).enrolSubscriber(any(), any())(any[HeaderCarrier])
+        verify(mockConnector, times(10)).enrolSubscriber(any(), any(), any())(any[HeaderCarrier])
       }
 
     }

--- a/test/services/TaxEnrolmentsServiceSpec.scala
+++ b/test/services/TaxEnrolmentsServiceSpec.scala
@@ -38,40 +38,42 @@ class TaxEnrolmentsServiceSpec extends BaseSpec {
     reset(mockConnector)
   }
 
-  ".setSubscriptionId" should {
+  ".setSubscriptionId 4MLD" should {
+
+    val taxable: Boolean = false
 
     "return TaxEnrolmentSuccess  " when {
       "connector returns success taxEnrolmentSuscriberResponse." in {
-        when(mockConnector.enrolSubscriber("123456789")).
+        when(mockConnector.enrolSubscriber("123456789", taxable)).
           thenReturn(Future.successful(TaxEnrolmentSuccess))
 
-        val futureResult = SUT.setSubscriptionId("123456789")
+        val futureResult = SUT.setSubscriptionId("123456789", taxable)
 
         whenReady(futureResult) {
           result => result mustBe TaxEnrolmentSuccess
         }
-        verify(mockConnector, times(1)).enrolSubscriber(any())(any[HeaderCarrier])
+        verify(mockConnector, times(1)).enrolSubscriber(any(), any())(any[HeaderCarrier])
       }
     }
 
     "return TaxEnrolmentFailure " when {
       "tax enrolment returns internal server error." in {
-        when(mockConnector.enrolSubscriber("123456789")).
+        when(mockConnector.enrolSubscriber("123456789", taxable)).
           thenReturn(Future.failed(new InternalServerErrorException("")))
-        val result = Await.result(SUT.setSubscriptionId("123456789"), Duration.Inf)
+        val result = Await.result(SUT.setSubscriptionId("123456789", taxable), Duration.Inf)
         result mustBe TaxEnrolmentFailure
-        verify(mockConnector, times(10)).enrolSubscriber(any())(any[HeaderCarrier])
+        verify(mockConnector, times(10)).enrolSubscriber(any(), any())(any[HeaderCarrier])
       }
     }
 
     "return TaxEnrolmentFailure " when {
       "tax enrolment returns error" in {
-        when(mockConnector.enrolSubscriber("123456789")).
+        when(mockConnector.enrolSubscriber("123456789", taxable)).
           thenReturn(Future.failed(BadRequestException))
 
-        val result = Await.result(SUT.setSubscriptionId("123456789"), Duration.Inf)
+        val result = Await.result(SUT.setSubscriptionId("123456789", taxable), Duration.Inf)
         result mustBe TaxEnrolmentFailure
-        verify(mockConnector, times(10)).enrolSubscriber(any())(any[HeaderCarrier])
+        verify(mockConnector, times(10)).enrolSubscriber(any(), any())(any[HeaderCarrier])
       }
 
     }

--- a/test/services/TaxEnrolmentsServiceSpec.scala
+++ b/test/services/TaxEnrolmentsServiceSpec.scala
@@ -38,7 +38,7 @@ class TaxEnrolmentsServiceSpec extends BaseSpec {
     reset(mockConnector)
   }
 
-  ".setSubscriptionId 4MLD" should {
+  ".setSubscriptionId" should {
 
     val taxable: Boolean = false
     val trn = "XTRN1234567"


### PR DESCRIPTION
Implement a custom callback endpoint for non-taxable trusts
Rename the current callback endpoint for taxable trusts (4MLD)
Going to switch the service name and callback endpoint provided to tax-enrolments if we know they're taxable or not