### PR TITLE
Simplify error handling to work for 4/5MLD

### DIFF
--- a/app/connector/DesConnector.scala
+++ b/app/connector/DesConnector.scala
@@ -128,11 +128,12 @@ class DesConnector @Inject()(http: HttpClient, config: AppConfig, trustsStoreSer
       s" getting playback for trust for correlationId: $correlationId")
 
     trustsStoreService.is5mldEnabled.flatMap { is5MLD =>
-      if (is5MLD) {
-        http.GET[GetTrustResponse](get5MLDTrustOrEstateEndpoint(identifier))(GetTrustResponse.httpReads, implicitly[HeaderCarrier](hc), global)
+      val url = if (is5MLD) {
+        get5MLDTrustOrEstateEndpoint(identifier)
       } else {
-        http.GET[GetTrustResponse](get4MLDTrustOrEstateEndpoint(identifier))(GetTrustResponse.httpReads, implicitly[HeaderCarrier](hc), global)
+        get4MLDTrustOrEstateEndpoint(identifier)
       }
+      http.GET[GetTrustResponse](url)(GetTrustResponse.httpReads(identifier), implicitly[HeaderCarrier](hc), global)
     }
   }
 

--- a/app/connector/DesConnector.scala
+++ b/app/connector/DesConnector.scala
@@ -128,12 +128,11 @@ class DesConnector @Inject()(http: HttpClient, config: AppConfig, trustsStoreSer
       s" getting playback for trust for correlationId: $correlationId")
 
     trustsStoreService.is5mldEnabled.flatMap { is5MLD =>
-      val url = if (is5MLD) {
-        get5MLDTrustOrEstateEndpoint(identifier)
+      if (is5MLD) {
+        http.GET[GetTrustResponse](get5MLDTrustOrEstateEndpoint(identifier))(GetTrustResponse.httpReads(identifier), implicitly[HeaderCarrier](hc), global)
       } else {
-        get4MLDTrustOrEstateEndpoint(identifier)
+        http.GET[GetTrustResponse](get4MLDTrustOrEstateEndpoint(identifier))(GetTrustResponse.httpReads(identifier), implicitly[HeaderCarrier](hc), global)
       }
-      http.GET[GetTrustResponse](url)(GetTrustResponse.httpReads(identifier), implicitly[HeaderCarrier](hc), global)
     }
   }
 

--- a/app/controllers/GetTrustController.scala
+++ b/app/controllers/GetTrustController.scala
@@ -39,8 +39,6 @@ class GetTrustController @Inject()(identify: IdentifierAction,
 
 
   val errorAuditMessages: Map[GetTrustResponse, String] = Map(
-    InvalidUTRResponse -> "The UTR/URN provided is invalid.",
-    InvalidRegimeResponse -> "Invalid regime received from DES.",
     BadRequestResponse -> "Bad Request received from DES.",
     ResourceNotFoundResponse -> "Not Found received from DES.",
     InternalServerErrorResponse -> "Internal Server Error received from DES.",
@@ -187,11 +185,9 @@ class GetTrustController @Inject()(identify: IdentifierAction,
     }
   }
 
-  private def doGet(identifier: String,
-                    applyTransformations: Boolean,
-                    refreshEtmpData: Boolean = false
-                   )
+  private def doGet(identifier: String, applyTransformations: Boolean, refreshEtmpData: Boolean = false)
                    (handleResult: GetTrustSuccessResponse => Result): Action[AnyContent] =
+
     (validateIdentifier(identifier) andThen identify).async {
       implicit request =>
 

--- a/app/controllers/GetTrustController.scala
+++ b/app/controllers/GetTrustController.scala
@@ -20,6 +20,7 @@ import controllers.actions.{IdentifierAction, ValidateIdentifierActionProvider}
 import javax.inject.{Inject, Singleton}
 import models.auditing.TrustAuditing
 import models.get_trust.{BadRequestResponse, _}
+import models.requests.IdentifierRequest
 import play.api.Logging
 import play.api.libs.json._
 import play.api.mvc.{Action, AnyContent, ControllerComponents, Result}
@@ -186,55 +187,70 @@ class GetTrustController @Inject()(identify: IdentifierAction,
   }
 
   private def doGet(identifier: String, applyTransformations: Boolean, refreshEtmpData: Boolean = false)
-                   (handleResult: GetTrustSuccessResponse => Result): Action[AnyContent] =
-
-    (validateIdentifier(identifier) andThen identify).async {
+                   (f: GetTrustSuccessResponse => Result): Action[AnyContent] = (validateIdentifier(identifier) andThen identify).async {
       implicit request =>
-
-        (for {
-          _ <- resetCacheIfRequested(identifier, request.identifier, refreshEtmpData)
-          data <- if (applyTransformations) {
-            transformationService.getTransformedData(identifier, request.identifier)
-          } else {
-            desService.getTrustInfo(identifier, request.identifier)
-          }
-        } yield data match {
-          case response: GetTrustSuccessResponse =>
-            auditService.audit(
-              event = TrustAuditing.GET_TRUST,
-              request = Json.obj("utr" -> identifier),
-              internalId = request.identifier,
-              response = Json.toJson(response)
-            )
-
-            handleResult(response)
-          case NotEnoughDataResponse(json, errors) =>
-            val reason = Json.obj(
-              "response" -> json,
-              "reason" -> "Missing mandatory fields in response received from DES",
-              "errors" -> errors
-            )
-
-            auditService.audit(
-              event = TrustAuditing.GET_TRUST,
-              request = Json.obj("utr" -> identifier),
-              internalId = request.identifier,
-              response = reason
-            )
-
-            NoContent
-          case err =>
-            auditService.auditErrorResponse(
-              TrustAuditing.GET_TRUST,
-              Json.obj("utr" -> identifier),
-              request.identifier,
-              errorAuditMessages.getOrElse(err, "UNKNOWN")
-            )
-            errorResponses.getOrElse(err, InternalServerError)
-        }) recover {
+        {
+          for {
+            _ <- resetCacheIfRequested(identifier, request.identifier, refreshEtmpData)
+            data <- if (applyTransformations) {
+              transformationService.getTransformedData(identifier, request.identifier)
+            } else {
+              desService.getTrustInfo(identifier, request.identifier)
+            }
+          } yield (
+            successResponse(f, identifier) orElse
+            notEnoughDataResponse(identifier) orElse
+            errorResponse(identifier)
+          ).apply(data)
+        } recover {
           case e =>
             logger.error(s"[Session ID: ${request.sessionId}][UTR/URN: $identifier] Failed to get trust info ${e.getMessage}")
             InternalServerError
         }
     }
+
+  private def successResponse(f: GetTrustSuccessResponse => Result,
+                              identifier: String)
+                             (implicit request: IdentifierRequest[AnyContent]): PartialFunction[GetTrustResponse, Result] = {
+    case response: GetTrustSuccessResponse =>
+      auditService.audit(
+        event = TrustAuditing.GET_TRUST,
+        request = Json.obj("utr" -> identifier),
+        internalId = request.identifier,
+        response = Json.toJson(response)
+      )
+
+      f(response)
+  }
+
+  private def notEnoughDataResponse(identifier: String)
+                           (implicit request: IdentifierRequest[AnyContent]): PartialFunction[GetTrustResponse, Result] = {
+    case NotEnoughDataResponse(json, errors) =>
+      val reason = Json.obj(
+        "response" -> json,
+        "reason" -> "Missing mandatory fields in response received from DES",
+        "errors" -> errors
+      )
+
+      auditService.audit(
+        event = TrustAuditing.GET_TRUST,
+        request = Json.obj("utr" -> identifier),
+        internalId = request.identifier,
+        response = reason
+      )
+
+      NoContent
+  }
+
+  private def errorResponse(identifier: String)
+                           (implicit request: IdentifierRequest[AnyContent]): PartialFunction[GetTrustResponse, Result] = {
+    case err =>
+      auditService.auditErrorResponse(
+        TrustAuditing.GET_TRUST,
+        Json.obj("utr" -> identifier),
+        request.identifier,
+        errorAuditMessages.getOrElse(err, "UNKNOWN")
+      )
+      errorResponses.getOrElse(err, InternalServerError)
+  }
 }

--- a/app/models/get_trust/ResponseModels.scala
+++ b/app/models/get_trust/ResponseModels.scala
@@ -20,10 +20,6 @@ import play.api.libs.json.JsValue
 
 sealed trait TrustErrorResponse extends GetTrustResponse
 
-case object InvalidUTRResponse extends TrustErrorResponse
-
-case object InvalidRegimeResponse extends TrustErrorResponse
-
 case object BadRequestResponse extends TrustErrorResponse
 
 case object ResourceNotFoundResponse extends TrustErrorResponse

--- a/test/connectors/ConnectorSpecHelper.scala
+++ b/test/connectors/ConnectorSpecHelper.scala
@@ -47,6 +47,19 @@ class ConnectorSpecHelper extends BaseSpec with WireMockHelper with IntegrationP
        | "reason": "Submission has not passed validation. Invalid Payload."
        |}""".stripMargin)
 
+  val jsonResponse4005mld: JsValue = Json.parse(
+    s"""
+       |{
+       |  "failures": [
+       |    {
+       |      "code" : "INVALID_IDTYPE",
+       |      "reason" : "Submission has not passed validation. Invalid parameter idType."
+       |    }
+       |  ]
+       |}
+     """.stripMargin
+  )
+
   val jsonResponseAlreadyRegistered: JsValue = Json.parse(
     s"""
        |{
@@ -100,6 +113,7 @@ class ConnectorSpecHelper extends BaseSpec with WireMockHelper with IntegrationP
        |}
      """.stripMargin
   )
+
 
   val jsonResponse400InvalidRegime: JsValue = Json.parse(
     s"""

--- a/test/connectors/DesConnectorSpec.scala
+++ b/test/connectors/DesConnectorSpec.scala
@@ -438,59 +438,9 @@ class DesConnectorSpec extends ConnectorSpecHelper {
 
       }
 
-      "return InvalidUTRResponse" when {
-
-        "des has returned a 400 with the code INVALID_UTR" in {
-
-          stubForGet(server, "/trusts-store/features/5mld", OK, Json.stringify(Json.parse(
-            """
-              |{
-              | "name": "5mld",
-              | "isEnabled": false
-              |}""".stripMargin
-          )))
-
-          val invalidUTR = "123456789"
-          stubForGet(server, get4MLDTrustEndpoint(invalidUTR), BAD_REQUEST,
-            Json.stringify(jsonResponse400InvalidUTR))
-
-          val futureResult = connector.getTrustInfo(invalidUTR)
-
-
-          whenReady(futureResult) { result =>
-            result mustBe InvalidUTRResponse
-          }
-        }
-      }
-
-      "return InvalidRegimeResponse" when {
-
-        "des has returned a 400 with the code INVALID_REGIME" in {
-
-          stubForGet(server, "/trusts-store/features/5mld", OK, Json.stringify(Json.parse(
-            """
-              |{
-              | "name": "5mld",
-              | "isEnabled": false
-              |}""".stripMargin
-          )))
-
-          val utr = "1234567891"
-          stubForGet(server, get4MLDTrustEndpoint(utr), BAD_REQUEST,
-            Json.stringify(jsonResponse400InvalidRegime))
-
-          val futureResult = connector.getTrustInfo(utr)
-
-
-          whenReady(futureResult) { result =>
-            result mustBe InvalidRegimeResponse
-          }
-        }
-      }
-
       "return BadRequestResponse" when {
 
-        "des has returned a 400 with a code which is not INVALID_UTR OR INVALID_REGIME" in {
+        "des has returned a 400" in {
 
           stubForGet(server, "/trusts-store/features/5mld", OK, Json.stringify(Json.parse(
             """
@@ -725,59 +675,9 @@ class DesConnectorSpec extends ConnectorSpecHelper {
 
         }
 
-        "return InvalidUTRResponse" when {
-
-          "des has returned a 400 with the code INVALID_UTR" in {
-
-            stubForGet(server, "/trusts-store/features/5mld", OK, Json.stringify(Json.parse(
-              """
-                |{
-                | "name": "5mld",
-                | "isEnabled": true
-                |}""".stripMargin
-            )))
-
-            val invalidUTR = "1234567890"
-            stubForGet(server, get5MLDTrustUTREndpoint(invalidUTR), BAD_REQUEST,
-              Json.stringify(jsonResponse400InvalidUTR))
-
-            val futureResult = connector.getTrustInfo(invalidUTR)
-
-
-            whenReady(futureResult) { result =>
-              result mustBe InvalidUTRResponse
-            }
-          }
-        }
-
-        "return InvalidRegimeResponse" when {
-
-          "des has returned a 400 with the code INVALID_REGIME" in {
-
-            stubForGet(server, "/trusts-store/features/5mld", OK, Json.stringify(Json.parse(
-              """
-                |{
-                | "name": "5mld",
-                | "isEnabled": true
-                |}""".stripMargin
-            )))
-
-            val utr = "1234567891"
-            stubForGet(server, get5MLDTrustUTREndpoint(utr), BAD_REQUEST,
-              Json.stringify(jsonResponse400InvalidRegime))
-
-            val futureResult = connector.getTrustInfo(utr)
-
-
-            whenReady(futureResult) { result =>
-              result mustBe InvalidRegimeResponse
-            }
-          }
-        }
-
         "return BadRequestResponse" when {
 
-          "des has returned a 400 with a code which is not INVALID_UTR OR INVALID_REGIME" in {
+          "des has returned a 400" in {
 
             stubForGet(server, "/trusts-store/features/5mld", OK, Json.stringify(Json.parse(
               """
@@ -792,7 +692,6 @@ class DesConnectorSpec extends ConnectorSpecHelper {
               Json.stringify(jsonResponse400))
 
             val futureResult = connector.getTrustInfo(utr)
-
 
             whenReady(futureResult) { result =>
               result mustBe BadRequestResponse
@@ -1010,57 +909,9 @@ class DesConnectorSpec extends ConnectorSpecHelper {
 
         }
 
-        "return InvalidUTRResponse" when {
-
-          "des has returned a 400 with the code INVALID_UTR" in {
-
-            stubForGet(server, "/trusts-store/features/5mld", OK, Json.stringify(Json.parse(
-              """
-                |{
-                | "name": "5mld",
-                | "isEnabled": true
-                |}""".stripMargin
-            )))
-
-            val urn = "1234567890ADCEF"
-            stubForGet(server, get5MLDTrustURNEndpoint(urn), BAD_REQUEST,
-              Json.stringify(jsonResponse400InvalidUTR))
-
-            val futureResult = connector.getTrustInfo(urn)
-
-            whenReady(futureResult) { result =>
-              result mustBe InvalidUTRResponse
-            }
-          }
-        }
-
-        "return InvalidRegimeResponse" when {
-
-          "des has returned a 400 with the code INVALID_REGIME" in {
-
-            stubForGet(server, "/trusts-store/features/5mld", OK, Json.stringify(Json.parse(
-              """
-                |{
-                | "name": "5mld",
-                | "isEnabled": true
-                |}""".stripMargin
-            )))
-
-            val urn = "1234567890ADCEF"
-            stubForGet(server, get5MLDTrustURNEndpoint(urn), BAD_REQUEST,
-              Json.stringify(jsonResponse400InvalidRegime))
-
-            val futureResult = connector.getTrustInfo(urn)
-
-            whenReady(futureResult) { result =>
-              result mustBe InvalidRegimeResponse
-            }
-          }
-        }
-
         "return BadRequestResponse" when {
 
-          "des has returned a 400 with a code which is not INVALID_UTR OR INVALID_REGIME" in {
+          "des has returned a 400" in {
 
             stubForGet(server, "/trusts-store/features/5mld", OK, Json.stringify(Json.parse(
               """
@@ -1072,7 +923,7 @@ class DesConnectorSpec extends ConnectorSpecHelper {
 
             val urn = "1234567890ADCEF"
             stubForGet(server, get5MLDTrustURNEndpoint(urn), BAD_REQUEST,
-              Json.stringify(jsonResponse400))
+              Json.stringify(jsonResponse4005mld))
 
             val futureResult = connector.getTrustInfo(urn)
 

--- a/test/services/DesServiceSpec.scala
+++ b/test/services/DesServiceSpec.scala
@@ -197,6 +197,7 @@ class DesServiceSpec extends BaseSpec {
   ".getTrustInfo" should {
 
     "return TrustFoundResponse" when {
+
       "TrustFoundResponse is returned from DES Connector with a Processed flag and a trust body when not cached" in new DesServiceFixture {
         val utr = "1234567890"
         val fullEtmpResponseJson = get4MLDTrustResponse
@@ -249,36 +250,8 @@ class DesServiceSpec extends BaseSpec {
       }
     }
 
-    "return InvalidUTRResponse" when {
-
-      "InvalidUTRResponse is returned from DES Connector" in new DesServiceFixture {
-
-        when(mockConnector.getTrustInfo(any())).thenReturn(Future.successful(InvalidUTRResponse))
-
-        val invalidUtr = "123456789"
-        val futureResult = SUT.getTrustInfo(invalidUtr, myId)
-
-        whenReady(futureResult) { result =>
-          result mustBe InvalidUTRResponse
-        }
-      }
-    }
-
-    "return InvalidRegimeResponse" when {
-      "InvalidRegimeResponse is returned from DES Connector" in new DesServiceFixture {
-
-        when(mockConnector.getTrustInfo(any())).thenReturn(Future.successful(InvalidRegimeResponse))
-
-        val utr = "123456789"
-        val futureResult = SUT.getTrustInfo(utr, myId)
-
-        whenReady(futureResult) { result =>
-          result mustBe InvalidRegimeResponse
-        }
-      }
-    }
-
     "return BadRequestResponse" when {
+
       "BadRequestResponse is returned from DES Connector" in new DesServiceFixture {
 
         when(mockConnector.getTrustInfo(any())).thenReturn(Future.successful(BadRequestResponse))
@@ -293,6 +266,7 @@ class DesServiceSpec extends BaseSpec {
     }
 
     "return ResourceNotFoundResponse" when {
+
       "ResourceNotFoundResponse is returned from DES Connector" in new DesServiceFixture {
 
         when(mockConnector.getTrustInfo(any())).thenReturn(Future.successful(ResourceNotFoundResponse))
@@ -307,6 +281,7 @@ class DesServiceSpec extends BaseSpec {
     }
 
     "return InternalServerErrorResponse" when {
+
       "InternalServerErrorResponse is returned from DES Connector" in new DesServiceFixture {
 
         when(mockConnector.getTrustInfo(any())).thenReturn(Future.successful(InternalServerErrorResponse))
@@ -321,6 +296,7 @@ class DesServiceSpec extends BaseSpec {
     }
 
     "return ServiceUnavailableResponse" when {
+
       "ServiceUnavailableResponse is returned from DES Connector" in new DesServiceFixture {
 
         when(mockConnector.getTrustInfo(any())).thenReturn(Future.successful(ServiceUnavailableResponse))
@@ -336,6 +312,7 @@ class DesServiceSpec extends BaseSpec {
   }
 
   ".trustVariation" should {
+
     "return a VariationTvnResponse" when {
 
       "connector returns VariationResponse." in new DesServiceFixture {


### PR DESCRIPTION
The structure of error responses from DES has changed in 5MLD.
It has moved from:
`
    {
      "code": "INVALID_REGIME",
      "reason": "The remote endpoint has indicated that the REGIME provided is invalid."
    }
`
to
`{
  "failures": [
    {
      "code": "INVALID_REGIME",
      "reason": "The remote endpoint has indicated that the REGIME provided is invalid."
    }
  ]
}`

This simplifies the code to no longer care about the response body of a bad request response and removes errors that could not occur.

Adds in missing tests for a URN identifier.