### PR TITLE
Revert "Revert "No longer mandating CR10 fields""

### DIFF
--- a/conf/resources/schemas/5MLD/trusts-api-registration-schema-1.3.0.json
+++ b/conf/resources/schemas/5MLD/trusts-api-registration-schema-1.3.0.json
@@ -1061,9 +1061,7 @@
         "startDate",
         "trustTaxable",
         "expressTrust",
-        "trustUKResident",
-        "trustRecorded",
-        "trustUKRelation"
+        "trustUKResident"
       ],
       "additionalProperties": false
     },


### PR DESCRIPTION
Cannot mandate as they need to remain optional for end to end testing.