### PR TITLE
TRUS-4141 [CS] upgrade bootstrap to 5.3 and sbt-auto-build to 3.0

### DIFF
--- a/app/controllers/OrchestratorCallbackController.scala
+++ b/app/controllers/OrchestratorCallbackController.scala
@@ -22,7 +22,7 @@ import play.api.libs.json.JsValue
 import play.api.mvc.{Action, ControllerComponents}
 import services.AuditService
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.play.HeaderCarrierConverter
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import utils.Session
 
@@ -34,7 +34,7 @@ class OrchestratorCallbackController @Inject()(auditService: AuditService, cc: C
 
   def migrationToTaxableCallback(urn: String, utr: String): Action[JsValue] = Action.async(parse.json) {
     implicit request =>
-      implicit val hc : HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(request.headers)
+      implicit val hc : HeaderCarrier = HeaderCarrierConverter.fromRequest(request)
 
       logger.info(s"[migrationToTaxableCallback][Session ID: ${Session.id(hc)}][URN: $urn, UTR: $utr]" +
         s" Orchestrator: migrate subscription callback message was: ${request.body}")

--- a/app/controllers/TaxEnrolmentCallbackController.scala
+++ b/app/controllers/TaxEnrolmentCallbackController.scala
@@ -22,7 +22,7 @@ import play.api.libs.json.JsValue
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import services.TaxableMigrationService
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.play.HeaderCarrierConverter
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import utils.Session
 
@@ -36,7 +36,7 @@ class TaxEnrolmentCallbackController @Inject()(migrationService: TaxableMigratio
 
   def taxableSubscriptionCallback(trn: String): Action[JsValue] = Action.async(parse.json) {
     implicit request =>
-      val hc : HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(request.headers)
+      val hc : HeaderCarrier = HeaderCarrierConverter.fromRequest(request)
 
       logger.info(s"[taxableSubscriptionCallback][Session ID: ${Session.id(hc)}][TRN: $trn]" +
         s" Tax-enrolment: taxable subscription callback message was: ${request.body}")
@@ -45,7 +45,7 @@ class TaxEnrolmentCallbackController @Inject()(migrationService: TaxableMigratio
 
   def nonTaxableSubscriptionCallback(trn: String): Action[JsValue] = Action.async(parse.json) {
     implicit request =>
-      val hc : HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(request.headers)
+      val hc : HeaderCarrier = HeaderCarrierConverter.fromRequest(request)
 
       logger.info(s"[nonTaxableSubscriptionCallback][Session ID: ${Session.id(hc)}][TRN: $trn]" +
         s" Tax-enrolment: non-taxable subscription callback message was: ${request.body}")
@@ -54,7 +54,7 @@ class TaxEnrolmentCallbackController @Inject()(migrationService: TaxableMigratio
 
   def migrationSubscriptionCallback(subscriptionId: String, urn: String): Action[AnyContent] = Action.async {
     implicit request =>
-      implicit val hc : HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(request.headers)
+      implicit val hc : HeaderCarrier = HeaderCarrierConverter.fromRequest(request)
 
       logger.info(s"[migrationSubscriptionCallback][Session ID: ${Session.id(hc)}][SubscriptionId: $subscriptionId, URN: $urn]" +
         s" Tax-enrolment: migration subscription callback triggered")

--- a/app/controllers/actions/IdentifierAction.scala
+++ b/app/controllers/actions/IdentifierAction.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
 import uk.gov.hmrc.auth.core.retrieve.~
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.play.HeaderCarrierConverter
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
 import models.registration.ApiResponse._
 import models.requests.IdentifierRequest
 import utils.Session
@@ -44,7 +44,7 @@ class AuthenticatedIdentifierAction @Inject()(override val authConnector: AuthCo
     val retrievals = Retrievals.internalId and
                      Retrievals.affinityGroup
 
-    implicit val hc : HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(request.headers)
+    implicit val hc : HeaderCarrier = HeaderCarrierConverter.fromRequest(request)
 
     authorised().retrieve(retrievals) {
       case Some(internalId) ~ Some(Agent) =>

--- a/app/controllers/testOnly/TrustMigrationTestController.scala
+++ b/app/controllers/testOnly/TrustMigrationTestController.scala
@@ -22,7 +22,7 @@ import play.api.Logging
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import services._
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.play.HeaderCarrierConverter
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
 import utils.{Session, ValidationUtil}
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -34,7 +34,7 @@ class TrustMigrationTestController @Inject()(migrationService: TaxableMigrationS
 
   def migrateToTaxable(subscriptionId: String, urn: String): Action[AnyContent] = Action.async {
     implicit request =>
-      implicit val hc : HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(request.headers)
+      implicit val hc : HeaderCarrier = HeaderCarrierConverter.fromRequest(request)
 
       logger.info(s"[migrateToTaxable][Session ID: ${Session.id(hc)}][SubscriptionId: $subscriptionId, URN: $urn]" +
         s" Tax-enrolment: migration subscription callback message was: ${request.body}")

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 import sbt.Keys.baseDirectory
-import uk.gov.hmrc.SbtArtifactory
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin.publishingSettings
 import uk.gov.hmrc.versioning.SbtGitVersioning.autoImport.majorVersion
 
@@ -19,7 +18,7 @@ lazy val scoverageSettings = {
 }
 
 lazy val microservice = Project(appName, file("."))
-  .enablePlugins(play.sbt.PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin, SbtArtifactory)
+  .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
   .disablePlugins(JUnitXmlReportPlugin) //Required to prevent https://github.com/scalatest/scalatest/issues/1427
   .settings(
     scalaVersion := "2.12.12",

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -9,7 +9,7 @@ object AppDependencies {
   val compile: Seq[ModuleID] = Seq(
     ws,
     "org.reactivemongo"         %% "play2-reactivemongo"        % "0.18.8-play27",
-    "uk.gov.hmrc"               %% "bootstrap-backend-play-27"  % "4.0.0",
+    "uk.gov.hmrc"               %% "bootstrap-backend-play-27"  % "5.3.0",
     "com.github.java-json-tools" % "json-schema-validator"      % "2.2.14"
   )
 
@@ -17,7 +17,7 @@ object AppDependencies {
     "org.scalatest"          %% "scalatest"           % "3.2.8",
     "org.mockito"             % "mockito-core"        % "3.10.0",
     "org.pegdown"            % "pegdown"              % "1.6.0",
-    "com.github.tomakehurst" % "wiremock-standalone"  % "2.25.1",
+    "com.github.tomakehurst" % "wiremock-standalone"  % "2.27.2",
     "org.mockito"            % "mockito-all"          % "1.10.19",
     "org.scalatestplus.play"  %% "scalatestplus-play" % "4.0.3",
     "org.scalatestplus"      %% "scalatestplus-mockito"    % "1.0.0-M2",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,9 +2,7 @@ resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.14.0")
-
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.0.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
 
@@ -14,4 +12,3 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.5.0")

--- a/test/services/AuditServiceSpec.scala
+++ b/test/services/AuditServiceSpec.scala
@@ -21,7 +21,6 @@ import models.auditing.{OrchestratorAuditEvent, VariationAuditEvent}
 import models.variation.VariationResponse
 import org.mockito.ArgumentMatchers.{any, eq => equalTo}
 import org.mockito.Mockito.verify
-import org.scalatest.matchers.must.Matchers._
 import play.api.libs.json.Json
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 


### PR DESCRIPTION
Might still need a bit of work? Quiet a few warnings around using the decprecated HeaderCarrierConverter when compiling
```
object HeaderCarrierConverter in package play is deprecated (since 13.0.0): Use uk.gov.hmrc.play.http.HeaderCarrierConverter instead

implicit val hc : HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(request.headers)
```