### PR TITLE
DDCE-3241 Candidate CPU fix - added Singletons and reduced ActorSyste…

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -17,11 +17,11 @@
 package config
 
 import javax.inject.{Inject, Singleton}
-import play.api.Configuration
+import play.api.{Configuration, Logging}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 @Singleton
-class AppConfig @Inject()(configuration: Configuration, servicesConfig: ServicesConfig) {
+class AppConfig @Inject()(configuration: Configuration, servicesConfig: ServicesConfig) extends Logging {
 
   val registrationBaseUrl : String = servicesConfig.baseUrl("registration")
   val subscriptionBaseUrl : String = servicesConfig.baseUrl("subscription")
@@ -94,5 +94,12 @@ class AppConfig @Inject()(configuration: Configuration, servicesConfig: Services
   val nrsRetryWaitMs = configuration.get[Int]("nrs.retryWaitMs")
   val nrsRetryWaitFactor = configuration.get[Int]("nrs.retryWaitFactor")
   val nrsTotalAttempts = configuration.get[Int]("nrs.totalAttempts")
+
+  logger.info(s"""=============== FEATURE FLAGS ===============
+                 |            nonRepudiate = ${nonRepudiate}
+                 |      dropIndexesEnabled = ${dropIndexesEnabled}
+                 |removeSavedRegistrations = ${removeSavedRegistrations}
+                 |=============== ============= ===============""".stripMargin)
+
 }
 

--- a/app/config/Module.scala
+++ b/app/config/Module.scala
@@ -17,20 +17,29 @@
 package config
 
 import com.google.inject.AbstractModule
+import connector.{TaxEnrolmentConnector, TaxEnrolmentConnectorImpl}
 import controllers.actions.{AuthenticatedIdentifierAction, IdentifierAction}
 import repositories._
+import retry.{NrsRetryHelper, RetryHelper}
+import services.rosm.{RosmPatternService, RosmPatternServiceImpl, TaxEnrolmentsService, TaxEnrolmentsServiceImpl}
 
 class Module extends AbstractModule {
 
   override def configure(): Unit = {
     // For session based storage instead of cred based, change to SessionIdentifierAction
-    bind(classOf[IdentifierAction]).to(classOf[AuthenticatedIdentifierAction])
+    bind(classOf[IdentifierAction]).to(classOf[AuthenticatedIdentifierAction]).asEagerSingleton()
 
     bind(classOf[MongoDriver]).to(classOf[TrustsMongoDriver]).asEagerSingleton()
 
-    bind(classOf[TransformationRepository]).to(classOf[TransformationRepositoryImpl])
-    bind(classOf[CacheRepository]).to(classOf[CacheRepositoryImpl])
-    bind(classOf[RegistrationSubmissionRepository]).to(classOf[RegistrationSubmissionRepositoryImpl])
-    bind(classOf[TaxableMigrationRepository]).to(classOf[TaxableMigrationRepositoryImpl])
+    bind(classOf[TransformationRepository]).to(classOf[TransformationRepositoryImpl]).asEagerSingleton()
+    bind(classOf[CacheRepository]).to(classOf[CacheRepositoryImpl]).asEagerSingleton()
+    bind(classOf[RegistrationSubmissionRepository]).to(classOf[RegistrationSubmissionRepositoryImpl]).asEagerSingleton()
+    bind(classOf[TaxableMigrationRepository]).to(classOf[TaxableMigrationRepositoryImpl]).asEagerSingleton()
+
+    bind(classOf[TaxEnrolmentConnector]).to(classOf[TaxEnrolmentConnectorImpl]).asEagerSingleton()
+    bind(classOf[TaxEnrolmentsService]).to(classOf[TaxEnrolmentsServiceImpl]).asEagerSingleton()
+    bind(classOf[RosmPatternService]).to(classOf[RosmPatternServiceImpl]).asEagerSingleton()
+
+    bind(classOf[RetryHelper]).to(classOf[NrsRetryHelper]).asEagerSingleton()
   }
 }

--- a/app/connector/NonRepudiationConnector.scala
+++ b/app/connector/NonRepudiationConnector.scala
@@ -18,7 +18,7 @@ package connector
 
 import config.AppConfig
 
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import models.nonRepudiation.{NRSSubmission, NRSResponse}
 import play.api.Logging
 import play.api.http.ContentTypes.JSON
@@ -28,6 +28,7 @@ import utils.Constants.{CONTENT_TYPE, X_API_KEY}
 import scala.concurrent.ExecutionContext.Implicits._
 import scala.concurrent.Future
 
+@Singleton
 class NonRepudiationConnector @Inject()(http: HttpClient, config: AppConfig) extends Logging {
 
   private def headers = Seq(CONTENT_TYPE -> JSON, X_API_KEY -> config.xApiKey)

--- a/app/connector/OrchestratorConnector.scala
+++ b/app/connector/OrchestratorConnector.scala
@@ -17,7 +17,7 @@
 package connector
 
 import config.AppConfig
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import models.orchestrator.OrchestratorMigrationRequest
 import models.tax_enrolments.OrchestratorToTaxableResponse
 import play.api.Logging
@@ -29,6 +29,7 @@ import utils.Session
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
+@Singleton
 class OrchestratorConnector @Inject()(http: HttpClient, config: AppConfig) extends Logging {
 
   private def headers = Seq(CONTENT_TYPE -> CONTENT_TYPE_JSON)

--- a/app/connector/SubscriptionConnector.scala
+++ b/app/connector/SubscriptionConnector.scala
@@ -19,17 +19,17 @@ package connector
 import java.util.UUID
 
 import config.AppConfig
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import models.tax_enrolments.SubscriptionIdResponse
 import play.api.Logging
 import play.api.http.HeaderNames
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
 import utils.Constants._
-import utils.Session
 
 import scala.concurrent.ExecutionContext.Implicits._
 import scala.concurrent.{ExecutionContext, Future}
 
+@Singleton
 class SubscriptionConnector @Inject()(http: HttpClient, config: AppConfig) extends Logging {
 
   private lazy val trustsServiceUrl : String = s"${config.subscriptionBaseUrl}/trusts"

--- a/app/connector/TaxEnrolmentConnector.scala
+++ b/app/connector/TaxEnrolmentConnector.scala
@@ -16,7 +16,6 @@
 
 package connector
 
-import com.google.inject.ImplementedBy
 import config.AppConfig
 import javax.inject.Inject
 import models.tax_enrolments.{TaxEnrolmentSubscriberResponse, TaxEnrolmentSubscription, TaxEnrolmentsSubscriptionsResponse}
@@ -24,7 +23,6 @@ import play.api.Logging
 import play.api.libs.json.{JsValue, Json, Writes}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
 import utils.Constants._
-import utils.Session
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -89,7 +87,6 @@ class TaxEnrolmentConnectorImpl @Inject()(http: HttpClient,
   }
 }
 
-@ImplementedBy(classOf[TaxEnrolmentConnectorImpl])
 trait TaxEnrolmentConnector {
 
   def getTaxEnrolmentSubscription(subscriptionId: String, taxable: Boolean, trn: String): TaxEnrolmentSubscription

--- a/app/connector/TrustsConnector.scala
+++ b/app/connector/TrustsConnector.scala
@@ -30,10 +30,11 @@ import utils.Constants._
 import utils.Session
 
 import java.util.UUID
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext.Implicits._
 import scala.concurrent.{ExecutionContext, Future}
 
+@Singleton
 class TrustsConnector @Inject()(http: HttpClient, config: AppConfig) extends Logging {
 
   private lazy val trustsServiceUrl: String =

--- a/app/retry/RetryHelper.scala
+++ b/app/retry/RetryHelper.scala
@@ -18,7 +18,6 @@ package retry
 
 import akka.actor.ActorSystem
 import akka.pattern.Patterns.after
-import com.google.inject.ImplementedBy
 import play.api.Logging
 import retry.RetryHelper.RetryExecution
 
@@ -28,10 +27,9 @@ import scala.concurrent.{ExecutionContext, Future}
 import utils.Session
 import uk.gov.hmrc.http.HeaderCarrier
 
-@ImplementedBy(classOf[NrsRetryHelper])
 trait RetryHelper extends Logging {
 
-  val as: ActorSystem = ActorSystem()
+  val as: ActorSystem = ActorSystem("RetryHelperActors")
 
   val maxAttempts: Int
   val factor: Int

--- a/app/services/AmendSubmissionDataService.scala
+++ b/app/services/AmendSubmissionDataService.scala
@@ -21,8 +21,9 @@ import play.api.libs.json._
 import services.dates.LocalDateService
 import utils.JsonOps.{JsValueOps, putNewValue}
 
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 
+@Singleton
 class AmendSubmissionDataService @Inject()(localDateService: LocalDateService) extends Logging {
 
   def applyRulesAndAddSubmissionDate(json: JsValue): JsValue = {

--- a/app/services/TaxYearService.scala
+++ b/app/services/TaxYearService.scala
@@ -21,7 +21,9 @@ import models.FirstTaxYearAvailable
 import uk.gov.hmrc.time.TaxYear
 
 import java.time.{LocalDate, MonthDay}
+import javax.inject.Singleton
 
+@Singleton
 class TaxYearService {
 
   def currentDate: LocalDate = LocalDate.now

--- a/app/services/TaxableMigrationService.scala
+++ b/app/services/TaxableMigrationService.scala
@@ -24,10 +24,11 @@ import services.auditing.MigrationAuditService
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.Session
 
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
+@Singleton
 class TaxableMigrationService @Inject()(
                                          auditService: MigrationAuditService,
                                          taxEnrolmentConnector: TaxEnrolmentConnector,

--- a/app/services/TransformationService.scala
+++ b/app/services/TransformationService.scala
@@ -31,10 +31,11 @@ import uk.gov.hmrc.http.HeaderCarrier
 import utils.Constants._
 import utils.Session
 
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
+@Singleton
 class TransformationService @Inject()(repository: TransformationRepository,
                                       trustsService: TrustsService,
                                       auditService: AuditService) extends Logging {

--- a/app/services/TrustsService.scala
+++ b/app/services/TrustsService.scala
@@ -28,10 +28,11 @@ import play.api.Logging
 import play.api.libs.json.{JsValue, Json}
 import repositories.CacheRepository
 
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
+@Singleton
 class TrustsService @Inject()(val trustsConnector: TrustsConnector,
                               val subscriptionConnector: SubscriptionConnector,
                               val repository: CacheRepository) extends Logging {

--- a/app/services/ValidationService.scala
+++ b/app/services/ValidationService.scala
@@ -25,11 +25,12 @@ import play.api.Logging
 import play.api.libs.json.{Format, JsPath, Json, JsonValidationError, Reads}
 import utils.BusinessValidation
 
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import scala.collection.JavaConverters._
 import scala.io.Source
 import scala.util.{Failure, Success, Try}
 
+@Singleton
 class ValidationService @Inject()() {
 
   private val factory = JsonSchemaFactory.byDefault()

--- a/app/services/VariationService.scala
+++ b/app/services/VariationService.scala
@@ -27,7 +27,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import utils.JsonOps._
 import utils.Session
 
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import models.tax_enrolments.{TaxEnrolmentNotProcessed, TaxEnrolmentSubscriberResponse}
 import services.auditing.VariationAuditService
 import services.dates.LocalDateService
@@ -35,6 +35,7 @@ import services.dates.LocalDateService
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
+@Singleton
 class VariationService @Inject()(
                                   trustsService: TrustsService,
                                   transformationService: TransformationService,

--- a/app/services/auditing/AuditService.scala
+++ b/app/services/auditing/AuditService.scala
@@ -21,8 +21,9 @@ import play.api.libs.json._
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 
+@Singleton
 class AuditService @Inject()(auditConnector: AuditConnector){
 
   import scala.concurrent.ExecutionContext.Implicits._

--- a/app/services/auditing/MigrationAuditService.scala
+++ b/app/services/auditing/MigrationAuditService.scala
@@ -21,9 +21,10 @@ import play.api.libs.json.{JsValue, Json}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext.Implicits.global
 
+@Singleton
 class MigrationAuditService @Inject()(auditConnector: AuditConnector)
   extends AuditService(auditConnector) {
 

--- a/app/services/auditing/NRSAuditService.scala
+++ b/app/services/auditing/NRSAuditService.scala
@@ -22,8 +22,9 @@ import play.api.libs.json.Json
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 
+@Singleton
 class NRSAuditService @Inject()(auditConnector: AuditConnector){
 
   import scala.concurrent.ExecutionContext.Implicits._

--- a/app/services/auditing/VariationAuditService.scala
+++ b/app/services/auditing/VariationAuditService.scala
@@ -23,8 +23,9 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import utils.Constants.{DETAILS, TAXABLE, TRUST}
 
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 
+@Singleton
 class VariationAuditService @Inject()(auditConnector: AuditConnector)
   extends AuditService(auditConnector) {
 

--- a/app/services/dates/LocalDateService.scala
+++ b/app/services/dates/LocalDateService.scala
@@ -17,7 +17,9 @@
 package services.dates
 
 import java.time.LocalDate
+import javax.inject.Singleton
 
+@Singleton
 class LocalDateService {
   def now: LocalDate = LocalDate.now
 }

--- a/app/services/dates/LocalDateTimeService.scala
+++ b/app/services/dates/LocalDateTimeService.scala
@@ -17,7 +17,9 @@
 package services.dates
 
 import java.time.{LocalDateTime, ZoneId}
+import javax.inject.Singleton
 
+@Singleton
 class LocalDateTimeService {
   def now: LocalDateTime = LocalDateTime.now
 

--- a/app/services/encoding/PayloadEncodingService.scala
+++ b/app/services/encoding/PayloadEncodingService.scala
@@ -20,6 +20,9 @@ import org.apache.commons.codec.binary.Base64
 import org.apache.commons.codec.digest.DigestUtils
 import play.api.libs.json.{JsValue, Json}
 
+import javax.inject.Singleton
+
+@Singleton
 class PayloadEncodingService {
 
   def encode(payload: JsValue): String =

--- a/app/services/nonRepudiation/NonRepudiationService.scala
+++ b/app/services/nonRepudiation/NonRepudiationService.scala
@@ -29,13 +29,14 @@ import services.auditing.NRSAuditService
 import services.dates.LocalDateTimeService
 import services.encoding.PayloadEncodingService
 import uk.gov.hmrc.http.HeaderCarrier
-import utils.{Headers, Session}
+import utils.Headers
 
 import java.time.ZoneOffset
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
+@Singleton
 class NonRepudiationService @Inject()(connector: NonRepudiationConnector,
                                       localDateTimeService: LocalDateTimeService,
                                       payloadEncodingService: PayloadEncodingService,

--- a/app/services/rosm/RosmPatternService.scala
+++ b/app/services/rosm/RosmPatternService.scala
@@ -16,7 +16,6 @@
 
 package services.rosm
 
-import com.google.inject.ImplementedBy
 import models.tax_enrolments.{TaxEnrolmentFailure, TaxEnrolmentNotProcessed, TaxEnrolmentSubscriberResponse, TaxEnrolmentSuccess}
 import play.api.Logging
 import services.TrustsService
@@ -68,7 +67,7 @@ class RosmPatternServiceImpl @Inject()(trustsService: TrustsService, taxEnrolmen
   }
 
 }
-@ImplementedBy(classOf[RosmPatternServiceImpl])
+
 trait RosmPatternService {
   def setSubscriptionId(trn: String, taxable: Boolean)(implicit hc: HeaderCarrier): Future[TaxEnrolmentSubscriberResponse]
   def enrolAndLogResult(trn: String, affinityGroup: AffinityGroup, taxable: Boolean)(implicit hc: HeaderCarrier): Future[TaxEnrolmentSubscriberResponse]

--- a/app/transformers/DeclarationTransformer.scala
+++ b/app/transformers/DeclarationTransformer.scala
@@ -26,7 +26,9 @@ import utils.JsonOps.{doNothing, prunePathAndPutNewValue, putNewValue}
 import utils.{DeedOfVariation, TypeOfTrust}
 
 import java.time.LocalDate
+import javax.inject.Singleton
 
+@Singleton
 class DeclarationTransformer {
 
   def transform(response: TrustProcessedResponse,


### PR DESCRIPTION
DDCE-3241 Candidate CPU fix - added Singletons and reduced ActorSystem creation.

Issues seen in live where CPU increases constantly and doesn't follow the normal M-curves that are typical for traffic. Performance tests in Staging re-produced the problem.

![image](https://user-images.githubusercontent.com/14215783/183098403-58a116bb-8f23-4bec-b1d2-6ded438222d9.png)

The problem could also be reproduced locally, e.g. by running the perf pack against the services.

The underlying issues were related to a couple of things, excessive instantiation of components and leaking ActorSystems. 
The first of these is fixed in two ways - for simple classes, the addition of the @Singleton annotation is sufficient; for split trait/implementation classes the Module has been extended and updated to use .asEagerSingleton.
The second was mainly due to ActorSystems being created on every call to the TaxEnrolments processing; there was also some leakage related to the NRS retry processing, but this was resolved via the Singleton solution.

Code was been tested locally to prove the leak no longer exists:
Before fix
![image](https://user-images.githubusercontent.com/14215783/183100222-86db68bc-a5dc-4393-a88f-d2b353492116.png)

After fix
![image](https://user-images.githubusercontent.com/14215783/183099859-5eeea4df-6912-432f-b905-e19c2dfed85b.png)

Also in Staging, a series of performance test runs have been executed on this code via a hotfix from the branch (v0.498.1)
![image](https://user-images.githubusercontent.com/14215783/183099743-60a0ad1e-3555-4e54-84ac-4d18c01bc73c.png)



