### PR TITLE
DDCE-3260 Fixed by closing the connection used to delete the database

### DIFF
--- a/it/uk/gov/hmrc/itbase/IntegrationTestBase.scala
+++ b/it/uk/gov/hmrc/itbase/IntegrationTestBase.scala
@@ -66,6 +66,7 @@ trait IntegrationTestBase extends ScalaFutures {
       val f: Future[Assertion] = for {
           connection <- getConnection()
           _ = dropTheDatabase(connection)
+          _ = connection.askClose()(Duration(1, "s"))
         } yield {
           block(application)
         }


### PR DESCRIPTION
The ITs were leaking a database connection that was used to delete the database - causing failures due to "Too many open files".